### PR TITLE
Add configuration module for WriterAgent

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2,14 +2,14 @@ import sys, pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import wordsmith.agent as agent
+from wordsmith.config import Config
 
 
-def test_writer_agent_runs(monkeypatch, tmp_path):
-    monkeypatch.setattr(agent, 'LOG_DIR', tmp_path / 'logs')
-    monkeypatch.setattr(agent, 'OUTPUT_DIR', tmp_path / 'output')
+def test_writer_agent_runs(tmp_path):
+    cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'output')
 
     steps = [agent.Step('intro'), agent.Step('body')]
-    writer = agent.WriterAgent('dogs', 5, steps, iterations=1)
+    writer = agent.WriterAgent('dogs', 5, steps, iterations=1, config=cfg)
     result = writer.run()
 
     assert len(result.split()) <= 5

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,11 +3,12 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import wordsmith.agent as agent
 from wordsmith import cli
+from wordsmith.config import Config
 
 
 def test_cli_main(monkeypatch, tmp_path, capsys):
-    monkeypatch.setattr(agent, 'LOG_DIR', tmp_path / 'logs')
-    monkeypatch.setattr(agent, 'OUTPUT_DIR', tmp_path / 'output')
+    cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'output')
+    monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
 
     inputs = iter(['Cats', '5', '1', '1', 'intro'])
     monkeypatch.setattr('builtins.input', lambda _: next(inputs))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,11 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from wordsmith.config import Config
+
+
+def test_config_creates_directories(tmp_path):
+    cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'output')
+    cfg.ensure_dirs()
+    assert cfg.log_dir.exists()
+    assert cfg.output_dir.exists()

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Iterable, List
 
-LOG_DIR = Path("logs")
-OUTPUT_DIR = Path("output")
+from .config import Config, DEFAULT_CONFIG
 
 
 @dataclass
@@ -25,18 +23,25 @@ class WriterAgent:
     natural language generation.
     """
 
-    def __init__(self, topic: str, word_count: int, steps: Iterable[Step], iterations: int) -> None:
+    def __init__(
+        self,
+        topic: str,
+        word_count: int,
+        steps: Iterable[Step],
+        iterations: int,
+        config: Config | None = None,
+    ) -> None:
         self.topic = topic
         self.word_count = word_count
         self.steps: List[Step] = list(steps)
         self.iterations = iterations
+        self.config = config or DEFAULT_CONFIG
 
-        LOG_DIR.mkdir(exist_ok=True)
-        OUTPUT_DIR.mkdir(exist_ok=True)
+        self.config.ensure_dirs()
 
         logging.basicConfig(
-            filename=LOG_DIR / "run.log",
-            level=logging.INFO,
+            filename=self.config.log_dir / self.config.log_file,
+            level=self.config.log_level,
             format="%(asctime)s - %(message)s",
             force=True,
         )
@@ -85,4 +90,6 @@ class WriterAgent:
     def _save_text(self, text: str) -> None:
         # Ensure a trailing newline so the shell prompt does not run into the
         # file contents when viewed with ``cat``.
-        (OUTPUT_DIR / "current_text.txt").write_text(text + "\n", encoding="utf8")
+        (self.config.output_dir / "current_text.txt").write_text(
+            text + "\n", encoding="utf8"
+        )

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import logging
+
+
+@dataclass
+class Config:
+    """Configuration options for the writing agent."""
+
+    log_dir: Path = Path("logs")
+    output_dir: Path = Path("output")
+    log_level: int = logging.INFO
+    log_file: str = "run.log"
+
+    def ensure_dirs(self) -> None:
+        """Create directories referenced in the configuration."""
+        self.log_dir.mkdir(exist_ok=True)
+        self.output_dir.mkdir(exist_ok=True)
+
+
+# Default configuration used by the application.
+DEFAULT_CONFIG = Config()


### PR DESCRIPTION
## Summary
- introduce Config dataclass for centralizing log and output settings
- allow WriterAgent to accept custom configuration
- cover configuration with tests and update existing tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a32824cfac8325966d2ee2895d339a