### PR TITLE
Clarify config usage and add output file option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,5 @@ Guidelines for coding agents working on this repository:
 - Run `pytest` and ensure all tests pass before committing.
 - Avoid adding external dependencies without discussion.
 - Generated artifacts like logs/ and output/ are ignored by git.
+- Store application settings in `wordsmith/config.py` rather than
+  scattering them throughout the codebase.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9,14 +9,18 @@ from wordsmith.config import Config
 
 
 def test_writer_agent_runs(tmp_path):
-    cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'output')
+    cfg = Config(
+        log_dir=tmp_path / 'logs',
+        output_dir=tmp_path / 'output',
+        output_file='story.txt',
+    )
 
     steps = [agent.Step('intro'), agent.Step('body')]
     writer = agent.WriterAgent('dogs', 5, steps, iterations=1, config=cfg)
     result = writer.run()
 
     assert len(result.split()) <= 5
-    assert (tmp_path / 'output' / 'current_text.txt').exists()
+    assert (tmp_path / 'output' / 'story.txt').exists()
     assert (tmp_path / 'logs' / 'run.log').exists()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,11 @@ from wordsmith.config import Config
 
 
 def test_cli_main(monkeypatch, tmp_path, capsys):
-    cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'output')
+    cfg = Config(
+        log_dir=tmp_path / 'logs',
+        output_dir=tmp_path / 'output',
+        output_file='story.txt',
+    )
     monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
 
     inputs = iter(['Cats', '5', '1', '1', 'stub', 'intro'])
@@ -18,4 +22,4 @@ def test_cli_main(monkeypatch, tmp_path, capsys):
     captured = capsys.readouterr()
     assert 'Final text:' in captured.out
     assert (tmp_path / 'logs' / 'run.log').exists()
-    assert (tmp_path / 'output' / 'current_text.txt').exists()
+    assert (tmp_path / 'output' / 'story.txt').exists()

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -125,6 +125,6 @@ class WriterAgent:
     def _save_text(self, text: str) -> None:
         # Ensure a trailing newline so the shell prompt does not run into the
         # file contents when viewed with ``cat``.
-        (self.config.output_dir / "current_text.txt").write_text(
+        (self.config.output_dir / self.config.output_file).write_text(
             text + "\n", encoding="utf8"
         )

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -12,6 +12,7 @@ class Config:
 
     log_dir: Path = Path("logs")
     output_dir: Path = Path("output")
+    output_file: str = "current_text.txt"
     log_level: int = logging.INFO
     log_file: str = "run.log"
     llm_provider: str = "stub"


### PR DESCRIPTION
## Summary
- Add `output_file` to central configuration and wire WriterAgent to use it
- Document that settings belong in `wordsmith/config.py`
- Extend tests and CLI test to verify configurable output file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a331dbf2bc832589022b17c6f01e89