### PR TITLE
feat: expose model and tuning options

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -30,6 +30,8 @@ def test_generate_with_ollama(monkeypatch, tmp_path):
         output_dir=tmp_path / 'output',
         llm_provider='ollama',
         model='test-model',
+        temperature=0.2,
+        context_length=128,
     )
 
     captured = {}
@@ -56,6 +58,8 @@ def test_generate_with_ollama(monkeypatch, tmp_path):
     assert result == 'ollama text'
     assert captured['url'] == cfg.ollama_url
     assert captured['data']['prompt'] == 'intro about cats'
+    assert captured['data']['options']['temperature'] == cfg.temperature
+    assert captured['data']['options']['num_ctx'] == cfg.context_length
 
 
 def test_generate_with_openai(monkeypatch, tmp_path):
@@ -65,6 +69,8 @@ def test_generate_with_openai(monkeypatch, tmp_path):
         llm_provider='openai',
         openai_api_key='test',
         model='gpt-test',
+        temperature=0.3,
+        context_length=64,
     )
 
     captured = {}
@@ -92,4 +98,6 @@ def test_generate_with_openai(monkeypatch, tmp_path):
     assert result == 'openai text'
     assert captured['url'] == cfg.openai_url
     assert captured['data']['messages'][0]['content'] == 'intro about cats'
+    assert captured['data']['temperature'] == cfg.temperature
+    assert captured['data']['max_tokens'] == cfg.context_length
     assert 'Authorization' in captured['headers']

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,28 @@ def test_cli_main(monkeypatch, tmp_path, capsys):
     )
     monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
 
-    inputs = iter(['Cats', '5', '1', '1', 'stub', 'intro'])
+    captured_cfg = {}
+    original_writer = agent.WriterAgent
+
+    def capturing_writer(topic, word_count, steps, iterations, config):
+        captured_cfg['config'] = config
+        return original_writer(topic, word_count, steps, iterations, config)
+
+    monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
+
+    inputs = iter(
+        [
+            'Cats',
+            '5',
+            '1',
+            '1',
+            'intro',
+            'stub',
+            'test-model',
+            '0.5',
+            '128',
+        ]
+    )
     monkeypatch.setattr('builtins.input', lambda _: next(inputs))
 
     cli.main()
@@ -23,3 +44,7 @@ def test_cli_main(monkeypatch, tmp_path, capsys):
     assert 'Final text:' in captured.out
     assert (tmp_path / 'logs' / 'run.log').exists()
     assert (tmp_path / 'output' / 'story.txt').exists()
+    assert captured_cfg['config'].llm_provider == 'stub'
+    assert captured_cfg['config'].model == 'test-model'
+    assert captured_cfg['config'].temperature == 0.5
+    assert captured_cfg['config'].context_length == 128

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,3 +9,5 @@ def test_config_creates_directories(tmp_path):
     cfg.ensure_dirs()
     assert cfg.log_dir.exists()
     assert cfg.output_dir.exists()
+    assert cfg.temperature == 0.7
+    assert cfg.context_length == 2048

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -90,9 +90,16 @@ class WriterAgent:
         prompt = f"{task} about {self.topic}"
 
         if self.config.llm_provider == "ollama":
-            data = json.dumps({"model": self.config.model, "prompt": prompt}).encode(
-                "utf8"
-            )
+            data = json.dumps(
+                {
+                    "model": self.config.model,
+                    "prompt": prompt,
+                    "options": {
+                        "temperature": self.config.temperature,
+                        "num_ctx": self.config.context_length,
+                    },
+                }
+            ).encode("utf8")
             req = urllib.request.Request(
                 self.config.ollama_url,
                 data=data,
@@ -112,6 +119,8 @@ class WriterAgent:
                 {
                     "model": self.config.model,
                     "messages": [{"role": "user", "content": prompt}],
+                    "temperature": self.config.temperature,
+                    "max_tokens": self.config.context_length,
                 }
             ).encode("utf8")
             req = urllib.request.Request(self.config.openai_url, data=data, headers=headers)

--- a/wordsmith/cli.py
+++ b/wordsmith/cli.py
@@ -11,16 +11,41 @@ def main() -> None:
     word_count = int(input("Word count: "))
     step_count = int(input("Number of steps: "))
     iterations = int(input("Iterations per step: "))
-    provider = (
-        input("LLM provider (stub/ollama/openai): ").strip()
-        or agent.DEFAULT_CONFIG.llm_provider
-    )
 
     steps: List[agent.Step] = []
     for i in range(1, step_count + 1):
         task = input(f"Task for step {i}: ")
         steps.append(agent.Step(task))
-    cfg = replace(agent.DEFAULT_CONFIG, llm_provider=provider)
+
+    provider = (
+        input("LLM provider (stub/ollama/openai): ").strip()
+        or agent.DEFAULT_CONFIG.llm_provider
+    )
+    model = input("Model name: ").strip() or agent.DEFAULT_CONFIG.model
+    temperature_input = (
+        input(f"Temperature [{agent.DEFAULT_CONFIG.temperature}]: ").strip()
+    )
+    temperature = (
+        float(temperature_input)
+        if temperature_input
+        else agent.DEFAULT_CONFIG.temperature
+    )
+    context_input = (
+        input(f"Context length [{agent.DEFAULT_CONFIG.context_length}]: ").strip()
+    )
+    context_length = (
+        int(context_input)
+        if context_input
+        else agent.DEFAULT_CONFIG.context_length
+    )
+
+    cfg = replace(
+        agent.DEFAULT_CONFIG,
+        llm_provider=provider,
+        model=model,
+        temperature=temperature,
+        context_length=context_length,
+    )
     writer = agent.WriterAgent(topic, word_count, steps, iterations, config=cfg)
     final_text = writer.run()
 

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -17,6 +17,8 @@ class Config:
     log_file: str = "run.log"
     llm_provider: str = "stub"
     model: str = "gpt-3.5-turbo"
+    temperature: float = 0.7
+    context_length: int = 2048
     openai_api_key: str | None = None
     openai_url: str = "https://api.openai.com/v1/chat/completions"
     ollama_url: str = "http://192.168.100.148:11434/api/generate"


### PR DESCRIPTION
## Summary
- allow CLI to select provider and configure model, temperature, and context length
- include temperature and context length in OpenAI and Ollama requests
- add tests for new configuration options

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3335677d08325b6016371a54482f9