### PR TITLE
Handle invalid numeric CLI inputs

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,3 +48,33 @@ def test_cli_main(monkeypatch, tmp_path, capsys):
     assert captured_cfg['config'].model == 'test-model'
     assert captured_cfg['config'].temperature == 0.5
     assert captured_cfg['config'].context_length == 128
+
+
+def test_cli_invalid_numeric_input(monkeypatch, tmp_path, capsys):
+    cfg = Config(
+        log_dir=tmp_path / 'logs',
+        output_dir=tmp_path / 'output',
+        output_file='story.txt',
+    )
+    monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
+
+    inputs = iter(
+        [
+            'Cats',
+            'five', '5',
+            '1',
+            '1',
+            'intro',
+            'stub',
+            'test-model',
+            'abc', '0.5',
+            'xyz', '128',
+        ]
+    )
+    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+
+    cli.main()
+
+    captured = capsys.readouterr()
+    assert captured.out.count('Invalid input') == 3
+    assert 'Final text:' in captured.out

--- a/wordsmith/cli.py
+++ b/wordsmith/cli.py
@@ -6,11 +6,33 @@ from typing import List
 import wordsmith.agent as agent
 
 
+def _prompt_int(prompt: str, default: int | None = None) -> int:
+    while True:
+        raw = input(prompt)
+        if not raw.strip() and default is not None:
+            return default
+        try:
+            return int(raw)
+        except ValueError:
+            print("Invalid input. Please enter a number.")
+
+
+def _prompt_float(prompt: str, default: float | None = None) -> float:
+    while True:
+        raw = input(prompt)
+        if not raw.strip() and default is not None:
+            return default
+        try:
+            return float(raw)
+        except ValueError:
+            print("Invalid input. Please enter a number.")
+
+
 def main() -> None:
     topic = input("Topic: ")
-    word_count = int(input("Word count: "))
-    step_count = int(input("Number of steps: "))
-    iterations = int(input("Iterations per step: "))
+    word_count = _prompt_int("Word count: ")
+    step_count = _prompt_int("Number of steps: ")
+    iterations = _prompt_int("Iterations per step: ")
 
     steps: List[agent.Step] = []
     for i in range(1, step_count + 1):
@@ -22,21 +44,13 @@ def main() -> None:
         or agent.DEFAULT_CONFIG.llm_provider
     )
     model = input("Model name: ").strip() or agent.DEFAULT_CONFIG.model
-    temperature_input = (
-        input(f"Temperature [{agent.DEFAULT_CONFIG.temperature}]: ").strip()
+    temperature = _prompt_float(
+        f"Temperature [{agent.DEFAULT_CONFIG.temperature}]: ",
+        default=agent.DEFAULT_CONFIG.temperature,
     )
-    temperature = (
-        float(temperature_input)
-        if temperature_input
-        else agent.DEFAULT_CONFIG.temperature
-    )
-    context_input = (
-        input(f"Context length [{agent.DEFAULT_CONFIG.context_length}]: ").strip()
-    )
-    context_length = (
-        int(context_input)
-        if context_input
-        else agent.DEFAULT_CONFIG.context_length
+    context_length = _prompt_int(
+        f"Context length [{agent.DEFAULT_CONFIG.context_length}]: ",
+        default=agent.DEFAULT_CONFIG.context_length,
     )
 
     cfg = replace(


### PR DESCRIPTION
## Summary
- prompt users again if numeric CLI inputs are invalid
- add test covering invalid numeric input handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3349eaef0832593fd373c5ba935f5