### PR TITLE
Fetch ollama models from server

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,3 +78,45 @@ def test_cli_invalid_numeric_input(monkeypatch, tmp_path, capsys):
     captured = capsys.readouterr()
     assert captured.out.count('Invalid input') == 3
     assert 'Final text:' in captured.out
+
+
+def test_cli_ollama_model_selection(monkeypatch, tmp_path, capsys):
+    cfg = Config(
+        log_dir=tmp_path / 'logs',
+        output_dir=tmp_path / 'output',
+        output_file='story.txt',
+    )
+    monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
+
+    monkeypatch.setattr(cli, '_fetch_ollama_models', lambda url: ['m1', 'm2'])
+
+    captured_cfg = {}
+    original_writer = agent.WriterAgent
+
+    def capturing_writer(topic, word_count, steps, iterations, config):
+        captured_cfg['config'] = config
+        return original_writer(topic, word_count, steps, iterations, config)
+
+    monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
+
+    inputs = iter(
+        [
+            'Cats',
+            '5',
+            '1',
+            '1',
+            'intro',
+            'ollama',
+            '2',
+            '0.5',
+            '128',
+        ]
+    )
+    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+
+    cli.main()
+
+    captured = capsys.readouterr()
+    assert 'Final text:' in captured.out
+    assert captured_cfg['config'].llm_provider == 'ollama'
+    assert captured_cfg['config'].model == 'm2'

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -22,6 +22,7 @@ class Config:
     openai_api_key: str | None = None
     openai_url: str = "https://api.openai.com/v1/chat/completions"
     ollama_url: str = "http://192.168.100.148:11436/api/generate"
+    ollama_list_url: str = "http://192.168.100.148:11436/api/tags"
 
     def ensure_dirs(self) -> None:
         """Create directories referenced in the configuration."""


### PR DESCRIPTION
## Summary
- add `ollama_list_url` setting for retrieving models from the server
- update CLI to fetch and present available Ollama models for selection
- cover new model selection workflow with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a341fc6b708325b2488f849c5c93e2