### PR TITLE
List available Ollama models for selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The program will prompt for:
 4. **Iterations per step** – how many times each phase should run.
 5. **Task for each step** – a short description of what should happen in that
    step.
+6. **LLM provider** – choose between the stub and real providers. When using
+   the Ollama provider, the available models are fetched automatically and you
+   can select one from a numbered list.
 
 During execution a log is written to `logs/run.log` and the current state of
 the text is stored in `output/current_text.txt`.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,3 +120,30 @@ def test_cli_ollama_model_selection(monkeypatch, tmp_path, capsys):
     assert 'Final text:' in captured.out
     assert captured_cfg['config'].llm_provider == 'ollama'
     assert captured_cfg['config'].model == 'm2'
+
+
+def test_cli_ollama_no_models(monkeypatch, tmp_path, capsys):
+    cfg = Config(
+        log_dir=tmp_path / 'logs',
+        output_dir=tmp_path / 'output',
+        output_file='story.txt',
+    )
+    monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
+
+    # Simulate no models being returned from Ollama
+    monkeypatch.setattr(cli, '_fetch_ollama_models', lambda url: [])
+
+    inputs = iter([
+        'Cats',
+        '5',
+        '1',
+        '1',
+        'intro',
+        'ollama',
+    ])
+    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+
+    cli.main()
+
+    captured = capsys.readouterr()
+    assert 'No models available from Ollama.' in captured.out

--- a/wordsmith/cli.py
+++ b/wordsmith/cli.py
@@ -57,14 +57,14 @@ def main() -> None:
     )
     if provider == "ollama":
         models = _fetch_ollama_models(agent.DEFAULT_CONFIG.ollama_list_url)
-        if models:
-            print("Available models:")
-            for i, name in enumerate(models, 1):
-                print(f"{i}. {name}")
-            choice = _prompt_int("Select model [1]: ", default=1)
-            model = models[min(max(choice, 1), len(models)) - 1]
-        else:
-            model = input("Model name: ").strip() or agent.DEFAULT_CONFIG.model
+        if not models:
+            print("No models available from Ollama.")
+            return
+        print("Available models:")
+        for i, name in enumerate(models, 1):
+            print(f"{i}. {name}")
+        choice = _prompt_int("Select model [1]: ", default=1)
+        model = models[min(max(choice, 1), len(models)) - 1]
     else:
         model = input("Model name: ").strip() or agent.DEFAULT_CONFIG.model
     temperature = _prompt_float(


### PR DESCRIPTION
## Summary
- Fetch and display available Ollama models, requiring users to pick from the list instead of entering names
- Return with a warning if no Ollama models are available
- Document and test the Ollama model selection behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a34607e4c48325a2689e18bf6e2e9c