### PR TITLE
Show generation progress with tokens per second

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -149,3 +149,20 @@ def test_run_uses_crafted_prompt(monkeypatch, tmp_path):
 
     assert any('Provide an optimal prompt' in c for c in calls)
     assert any('Current text:' in c for c in calls)
+
+
+def test_run_reports_progress(monkeypatch, tmp_path, capsys):
+    cfg = Config(
+        log_dir=tmp_path / 'logs',
+        output_dir=tmp_path / 'output',
+        output_file='story.txt',
+    )
+
+    steps = [agent.Step('intro')]
+    writer = agent.WriterAgent('cats', 5, steps, iterations=1, config=cfg)
+
+    writer.run()
+
+    out = capsys.readouterr().out
+    assert 'step 1/1 iteration 1/1' in out
+    assert 'tok/s' in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,7 @@ def test_cli_main(monkeypatch, tmp_path, capsys):
 
     captured = capsys.readouterr()
     assert 'Final text:' in captured.out
+    assert 'tok/s' in captured.out
     assert (tmp_path / 'logs' / 'run.log').exists()
     assert (tmp_path / 'output' / 'story.txt').exists()
     assert captured_cfg['config'].llm_provider == 'stub'
@@ -78,6 +79,7 @@ def test_cli_invalid_numeric_input(monkeypatch, tmp_path, capsys):
     captured = capsys.readouterr()
     assert captured.out.count('Invalid input') == 3
     assert 'Final text:' in captured.out
+    assert 'tok/s' in captured.out
 
 
 def test_cli_ollama_model_selection(monkeypatch, tmp_path, capsys):
@@ -118,6 +120,7 @@ def test_cli_ollama_model_selection(monkeypatch, tmp_path, capsys):
 
     captured = capsys.readouterr()
     assert 'Final text:' in captured.out
+    assert 'tok/s' in captured.out
     assert captured_cfg['config'].llm_provider == 'ollama'
     assert captured_cfg['config'].model == 'm2'
 

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import json
 import logging
 import os
-import urllib.request
+import time
 import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from typing import Iterable, List
 
@@ -69,7 +70,11 @@ class WriterAgent:
             prompt = self._craft_prompt(step.task)
             for iteration in range(1, self.iterations + 1):
                 current_text = " ".join(text)
+                start = time.perf_counter()
                 addition = self._generate(prompt, current_text, iteration)
+                elapsed = time.perf_counter() - start
+                tokens = len(addition.split())
+                tok_per_sec = tokens / (elapsed or 1e-8)
                 text.append(addition)
                 current_text = " ".join(text)
                 self._save_text(current_text)
@@ -80,6 +85,11 @@ class WriterAgent:
                     iteration,
                     self.iterations,
                     addition,
+                )
+                print(
+                    f"step {step_index}/{len(self.steps)} iteration {iteration}/{self.iterations}: "
+                    f"{tokens} tokens ({tok_per_sec:.2f} tok/s)",
+                    flush=True,
                 )
 
         final_text = " ".join(text)


### PR DESCRIPTION
## Summary
- display progress for each generation step and report tokens per second
- verify progress output through new unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3509acc088325ac0d664b979354ae