### PR TITLE
Add configurable max tokens and CLI defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ The program will prompt for:
 6. **LLM provider** – choose between the stub and real providers. When using
    the Ollama provider, the available models are fetched automatically and you
    can select one from a numbered list.
+7. **Model name** – which LLM model to use.
+8. **Temperature** – randomness of the model's output.
+9. **Context length** – maximum token context for the model.
+10. **Max tokens** – limit for tokens generated per request.
+
+Each prompt displays a default value in square brackets. Pressing Enter
+accepts the default.
 
 During execution a log is written to `logs/run.log` and the current state of
 the text is stored in `output/current_text.txt`.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -33,6 +33,7 @@ def test_call_llm_with_ollama(monkeypatch, tmp_path):
         model='test-model',
         temperature=0.2,
         context_length=128,
+        max_tokens=50,
     )
 
     captured = {}
@@ -62,6 +63,7 @@ def test_call_llm_with_ollama(monkeypatch, tmp_path):
     assert captured['data']['prompt'] == expected_prompt
     assert captured['data']['options']['temperature'] == cfg.temperature
     assert captured['data']['options']['num_ctx'] == cfg.context_length
+    assert captured['data']['options']['num_predict'] == cfg.max_tokens
 
 
 def test_call_llm_with_openai(monkeypatch, tmp_path):
@@ -73,6 +75,7 @@ def test_call_llm_with_openai(monkeypatch, tmp_path):
         model='gpt-test',
         temperature=0.3,
         context_length=64,
+        max_tokens=40,
     )
 
     captured = {}
@@ -103,7 +106,7 @@ def test_call_llm_with_openai(monkeypatch, tmp_path):
     assert captured['data']['messages'][0]['content'] == writer.system_prompt
     assert captured['data']['messages'][1]['content'] == 'intro about cats'
     assert captured['data']['temperature'] == cfg.temperature
-    assert captured['data']['max_tokens'] == cfg.context_length
+    assert captured['data']['max_tokens'] == cfg.max_tokens
     assert 'Authorization' in captured['headers']
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,3 +11,4 @@ def test_config_creates_directories(tmp_path):
     assert cfg.output_dir.exists()
     assert cfg.temperature == 0.7
     assert cfg.context_length == 2048
+    assert cfg.max_tokens == 256

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -134,6 +134,7 @@ class WriterAgent:
                     "options": {
                         "temperature": self.config.temperature,
                         "num_ctx": self.config.context_length,
+                        "num_predict": self.config.max_tokens,
                     },
                 }
             ).encode("utf8")
@@ -164,7 +165,7 @@ class WriterAgent:
                         {"role": "user", "content": prompt},
                     ],
                     "temperature": self.config.temperature,
-                    "max_tokens": self.config.context_length,
+                    "max_tokens": self.config.max_tokens,
                 }
             ).encode("utf8")
             req = urllib.request.Request(self.config.openai_url, data=data, headers=headers)

--- a/wordsmith/cli.py
+++ b/wordsmith/cli.py
@@ -41,18 +41,22 @@ def _fetch_ollama_models(url: str) -> List[str]:
 
 
 def main() -> None:
-    topic = input("Topic: ")
-    word_count = _prompt_int("Word count: ")
-    step_count = _prompt_int("Number of steps: ")
-    iterations = _prompt_int("Iterations per step: ")
+    default_topic = "Untitled"
+    topic = input(f"Topic [{default_topic}]: ").strip() or default_topic
+    word_count = _prompt_int("Word count [100]: ", default=100)
+    step_count = _prompt_int("Number of steps [1]: ", default=1)
+    iterations = _prompt_int("Iterations per step [1]: ", default=1)
 
     steps: List[agent.Step] = []
     for i in range(1, step_count + 1):
-        task = input(f"Task for step {i}: ")
+        default_task = f"Step {i}"
+        task = input(f"Task for step {i} [{default_task}]: ").strip() or default_task
         steps.append(agent.Step(task))
 
     provider = (
-        input("LLM provider (stub/ollama/openai): ").strip()
+        input(
+            f"LLM provider (stub/ollama/openai) [{agent.DEFAULT_CONFIG.llm_provider}]: "
+        ).strip()
         or agent.DEFAULT_CONFIG.llm_provider
     )
     if provider == "ollama":
@@ -66,7 +70,10 @@ def main() -> None:
         choice = _prompt_int("Select model [1]: ", default=1)
         model = models[min(max(choice, 1), len(models)) - 1]
     else:
-        model = input("Model name: ").strip() or agent.DEFAULT_CONFIG.model
+        model = (
+            input(f"Model name [{agent.DEFAULT_CONFIG.model}]: ").strip()
+            or agent.DEFAULT_CONFIG.model
+        )
     temperature = _prompt_float(
         f"Temperature [{agent.DEFAULT_CONFIG.temperature}]: ",
         default=agent.DEFAULT_CONFIG.temperature,
@@ -75,6 +82,10 @@ def main() -> None:
         f"Context length [{agent.DEFAULT_CONFIG.context_length}]: ",
         default=agent.DEFAULT_CONFIG.context_length,
     )
+    max_tokens = _prompt_int(
+        f"Max tokens [{agent.DEFAULT_CONFIG.max_tokens}]: ",
+        default=agent.DEFAULT_CONFIG.max_tokens,
+    )
 
     cfg = replace(
         agent.DEFAULT_CONFIG,
@@ -82,6 +93,7 @@ def main() -> None:
         model=model,
         temperature=temperature,
         context_length=context_length,
+        max_tokens=max_tokens,
     )
     writer = agent.WriterAgent(topic, word_count, steps, iterations, config=cfg)
     final_text = writer.run()

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -19,6 +19,7 @@ class Config:
     model: str = "gpt-3.5-turbo"
     temperature: float = 0.7
     context_length: int = 2048
+    max_tokens: int = 256
     openai_api_key: str | None = None
     openai_url: str = "https://api.openai.com/v1/chat/completions"
     ollama_url: str = "http://192.168.100.148:11434/api/generate"


### PR DESCRIPTION
## Summary
- allow configuring maximum tokens for generation
- show and use default values for all CLI prompts
- document new options and cover defaults with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3532c59bc8325b53a1b16e44a96d1