### PR TITLE
Add pyproject-based packaging and declare dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wordsmith"
+version = "0.1.0"
+description = "A tiny demonstration project for an iterative writing agent."
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+authors = [{name = "WordSmith Maintainers"}]
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=8"]
+
+[tool.setuptools.packages.find]
+include = ["wordsmith*"]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,10 @@
+import tomllib
+from pathlib import Path
+
+def test_pyproject_metadata():
+    data = tomllib.loads(Path("pyproject.toml").read_text())
+    project = data["project"]
+    assert project["name"] == "wordsmith"
+    assert project["dependencies"] == []
+    dev_deps = project.get("optional-dependencies", {}).get("dev", [])
+    assert any(dep.startswith("pytest") for dep in dev_deps)


### PR DESCRIPTION
## Summary
- Add `pyproject.toml` with project metadata and development dependency on pytest
- Verify packaging configuration via a new test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3613cdeb4832582d62939fc32c104