### PR TITLE
Add progress indicator for automatic mode

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -217,4 +217,5 @@ def test_run_auto_requests_prompt(monkeypatch, tmp_path, capsys):
     out = capsys.readouterr().out
     assert any('nächste Schritt' in c for c in calls)
     assert 'iteration 1/2' in out
+    assert '[##########----------]' in out
     assert (tmp_path / 'output' / 'story.txt').exists()

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -149,8 +149,11 @@ class WriterAgent:
             self.logger.info(
                 "iteration %s/%s: %s", iteration, self.iterations, addition
             )
+            bar_len = 20
+            filled = int(bar_len * iteration / self.iterations)
+            bar = "#" * filled + "-" * (bar_len - filled)
             print(
-                f"iteration {iteration}/{self.iterations}: "
+                f"iteration {iteration}/{self.iterations} [{bar}]: "
                 f"{tokens} tokens ({tok_per_sec:.2f} tok/s)",
                 flush=True,
             )


### PR DESCRIPTION
## Summary
- show a simple progress bar for each iteration when running the writer in automatic mode
- verify progress bar output in tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a37e890afc8325bf55b48aa07bb374