### PR TITLE
Move system prompt to prompts module

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -160,6 +160,18 @@ def test_meta_prompt_includes_word_count():
     assert 'Gewünschte Länge' in formatted
 
 
+def test_system_prompt_template(tmp_path):
+    cfg = Config(
+        log_dir=tmp_path / 'logs',
+        output_dir=tmp_path / 'output',
+        output_file='story.txt',
+    )
+    writer = agent.WriterAgent('cats', 5, [agent.Step('intro')], iterations=1, config=cfg)
+    expected = prompts.SYSTEM_PROMPT.format(topic='cats')
+    assert writer.system_prompt == expected
+    assert 'cats' in expected
+
+
 def test_run_uses_crafted_prompt(monkeypatch, tmp_path):
     cfg = Config(
         log_dir=tmp_path / 'logs',

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -50,9 +50,7 @@ class WriterAgent:
         # System prompt derived from the user's topic. This is attached to every
         # LLM request so that the model understands the overall context of the
         # writing task.
-        self.system_prompt = (
-            f"You are a helpful writing assistant focused on {self.topic}."
-        )
+        self.system_prompt = prompts.SYSTEM_PROMPT.format(topic=self.topic)
 
         logging.basicConfig(
             filename=self.config.log_dir / self.config.log_file,

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -1,5 +1,7 @@
 """Prompt templates used by WriterAgent."""
 
+SYSTEM_PROMPT = "You are a helpful writing assistant focused on {topic}."
+
 META_PROMPT = (
     "Titel: {title}\n"
     "Gewünschter Inhalt: {content}\n"


### PR DESCRIPTION
## Summary
- centralize system prompt in prompts module
- test system prompt formatting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a38fa28d1c8325847bfdabcb5c95c1