### PR TITLE
Handle KeyboardInterrupt in CLI

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -270,3 +270,12 @@ def test_cli_auto_mode_openai_endpoint(monkeypatch, tmp_path, capsys):
     assert cfg_used.llm_provider == 'openai'
     assert cfg_used.model == 'gpt'
     assert cfg_used.openai_url == 'http://custom'
+
+
+def test_cli_keyboard_interrupt(monkeypatch, capsys):
+    monkeypatch.setattr('builtins.input', lambda _: (_ for _ in ()).throw(KeyboardInterrupt))
+
+    cli.main()
+
+    out = capsys.readouterr().out
+    assert 'Exiting...' in out

--- a/wordsmith/cli.py
+++ b/wordsmith/cli.py
@@ -40,7 +40,7 @@ def _fetch_ollama_models(url: str) -> List[str]:
         return []
 
 
-def main() -> None:
+def _main_impl() -> None:
     if input("Automatic mode? (y/N): ").strip().lower() == "y":
         default_topic = "Untitled"
         topic = input(f"Title [{default_topic}]: ").strip() or default_topic
@@ -179,6 +179,13 @@ def main() -> None:
 
     print("\nFinal text:\n")
     print(final_text)
+
+
+def main() -> None:
+    try:
+        _main_impl()
+    except KeyboardInterrupt:
+        print("\nExiting...")
 
 
 if __name__ == "__main__":

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -7,6 +7,6 @@ META_PROMPT = (
     "Es Soll darin um diesen Inhalt gehen : {content}\n"
     "Die Gewünschte Länge des Fertigen Texttes soll etwa: {word_count} Wörter\n"
     "Aktueller Stand des Texttes ist:\n{current_text}\n\n"
-    "was ist der nächste Sinnvolle Schritt um diese Text besser zu machen, "
+    "was ist der nächste Schritt um diese Text besser zu machen, "
     "gib mir nur den nötigen prompt für ein LLM, mit einer eine Anweisung um am Text Weiter zu Arbeiten"
 )


### PR DESCRIPTION
## Summary
- allow CTRL+C to exit CLI gracefully
- cover interrupt handling with new test
- fix meta prompt wording to satisfy tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3926d30848325b5094542440d9461