### PR TITLE
Use UTF-16 for logging

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -140,7 +140,7 @@ def test_call_llm_logs_prompt_and_response(tmp_path):
     assert result == 'hello'
     log_path = tmp_path / 'logs' / cfg.llm_log_file
     assert log_path.exists()
-    content = log_path.read_text()
+    content = log_path.read_text(encoding='utf-16')
     assert 'say hi' in content
     assert 'hello' in content
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,7 @@ def test_config_creates_directories(tmp_path):
     assert cfg.temperature == 0.7
     assert cfg.context_length == 2048
     assert cfg.max_tokens == 256
+    assert cfg.log_encoding == 'utf-16'
 
 
 def test_adjust_for_word_count():

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,20 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import codecs
+
+import wordsmith.agent as agent
+from wordsmith.config import Config
+
+
+def test_logs_use_utf16(tmp_path):
+    cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'out')
+    writer = agent.WriterAgent('topic', 5, [], iterations=1, config=cfg)
+    writer.logger.info('unicode ✓')
+    writer.llm_logger.info('prompt: 你好')
+    run_data = (cfg.log_dir / cfg.log_file).read_bytes()
+    llm_data = (cfg.log_dir / cfg.llm_log_file).read_bytes()
+    for data, expected in [(run_data, 'unicode ✓'), (llm_data, 'prompt: 你好')]:
+        assert data.startswith(codecs.BOM_UTF16_LE) or data.startswith(codecs.BOM_UTF16_BE)
+        text = data.decode('utf-16')
+        assert expected in text

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -56,12 +56,14 @@ class WriterAgent:
             filename=self.config.log_dir / self.config.log_file,
             level=self.config.log_level,
             format="%(asctime)s - %(message)s",
+            encoding=self.config.log_encoding,
             force=True,
         )
         self.logger = logging.getLogger(__name__)
 
         llm_handler = logging.FileHandler(
-            self.config.log_dir / self.config.llm_log_file
+            self.config.log_dir / self.config.llm_log_file,
+            encoding=self.config.log_encoding,
         )
         llm_handler.setFormatter(logging.Formatter("%(asctime)s - %(message)s"))
         llm_handler.setLevel(self.config.log_level)

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -16,6 +16,7 @@ class Config:
     log_level: int = logging.INFO
     log_file: str = "run.log"
     llm_log_file: str = "llm.log"
+    log_encoding: str = "utf-16"
     llm_provider: str = "stub"
     model: str = "gpt-3.5-turbo"
     temperature: float = 0.7


### PR DESCRIPTION
## Summary
- configure logging system to write log files using UTF-16
- add tests verifying UTF-16 logging and update existing tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a41577088c832582da33f3b60d3a97