### PR TITLE
Graceful CLI exit on Ctrl+C

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -270,3 +270,15 @@ def test_cli_auto_mode_openai_endpoint(monkeypatch, tmp_path, capsys):
     assert cfg_used.llm_provider == 'openai'
     assert cfg_used.model == 'gpt'
     assert cfg_used.openai_url == 'http://custom'
+
+
+def test_cli_keyboard_interrupt(monkeypatch, capsys):
+    def raise_interrupt(_):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr('builtins.input', raise_interrupt)
+
+    cli.main()
+
+    out = capsys.readouterr().out
+    assert 'Aborted.' in out

--- a/wordsmith/cli.py
+++ b/wordsmith/cli.py
@@ -40,7 +40,7 @@ def _fetch_ollama_models(url: str) -> List[str]:
         return []
 
 
-def main() -> None:
+def _run_cli() -> None:
     if input("Automatic mode? (y/N): ").strip().lower() == "y":
         default_topic = "Untitled"
         topic = input(f"Title [{default_topic}]: ").strip() or default_topic
@@ -179,6 +179,13 @@ def main() -> None:
 
     print("\nFinal text:\n")
     print(final_text)
+
+
+def main() -> None:
+    try:
+        _run_cli()
+    except KeyboardInterrupt:
+        print("\nAborted.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Wrap CLI execution to handle `KeyboardInterrupt`
- Add regression test for graceful Ctrl+C termination

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4173a91cc8325bfc146cd9884eba2