### PR TITLE
Default log files to UTF-8

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -140,7 +140,7 @@ def test_call_llm_logs_prompt_and_response(tmp_path):
     assert result == 'hello'
     log_path = tmp_path / 'logs' / cfg.llm_log_file
     assert log_path.exists()
-    content = log_path.read_text(encoding='utf-16')
+    content = log_path.read_text(encoding='utf-8')
     assert 'say hi' in content
     assert 'hello' in content
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,7 @@ def test_config_creates_directories(tmp_path):
     assert cfg.temperature == 0.7
     assert cfg.context_length == 2048
     assert cfg.max_tokens == 256
-    assert cfg.log_encoding == 'utf-16'
+    assert cfg.log_encoding == 'utf-8'
 
 
 def test_adjust_for_word_count():

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,20 +1,21 @@
 import sys, pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
-import codecs
-
 import wordsmith.agent as agent
 from wordsmith.config import Config
 
 
-def test_logs_use_utf16(tmp_path):
-    cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'out')
-    writer = agent.WriterAgent('topic', 5, [], iterations=1, config=cfg)
-    writer.logger.info('unicode ✓')
-    writer.llm_logger.info('prompt: 你好')
+def test_logs_use_utf8(tmp_path):
+    cfg = Config(log_dir=tmp_path / "logs", output_dir=tmp_path / "out")
+    writer = agent.WriterAgent("topic", 5, [], iterations=1, config=cfg)
+    writer.logger.info("unicode \u2713")
+    writer.llm_logger.info("prompt: \u4f60\u597d")
     run_data = (cfg.log_dir / cfg.log_file).read_bytes()
     llm_data = (cfg.log_dir / cfg.llm_log_file).read_bytes()
-    for data, expected in [(run_data, 'unicode ✓'), (llm_data, 'prompt: 你好')]:
-        assert data.startswith(codecs.BOM_UTF16_LE) or data.startswith(codecs.BOM_UTF16_BE)
-        text = data.decode('utf-16')
+    for data, expected in [
+        (run_data, "unicode \u2713"),
+        (llm_data, "prompt: \u4f60\u597d"),
+    ]:
+        assert b"\x00" not in data
+        text = data.decode("utf-8")
         assert expected in text

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -16,7 +16,7 @@ class Config:
     log_level: int = logging.INFO
     log_file: str = "run.log"
     llm_log_file: str = "llm.log"
-    log_encoding: str = "utf-16"
+    log_encoding: str = "utf-8"
     llm_provider: str = "stub"
     model: str = "gpt-3.5-turbo"
     temperature: float = 0.7


### PR DESCRIPTION
## Summary
- Use UTF-8 for log files to avoid spacing artifacts when viewed with UTF-8 readers
- Update tests to validate UTF-8 encoded logs and configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a43517a9e083259c160cb601947e2a