### PR TITLE
Add text type option for automatic mode

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -152,6 +152,7 @@ def test_default_meta_prompt_contains_next_step_phrase():
 def test_meta_prompt_includes_word_count():
     formatted = prompts.META_PROMPT.format(
         title='T',
+        text_type='Text',
         content='C',
         word_count=123,
         current_text='',
@@ -167,7 +168,7 @@ def test_system_prompt_template(tmp_path):
         output_file='story.txt',
     )
     writer = agent.WriterAgent('cats', 5, [agent.Step('intro')], iterations=1, config=cfg)
-    expected = prompts.SYSTEM_PROMPT.format(topic='cats')
+    expected = prompts.SYSTEM_PROMPT.format(topic='cats', text_type='Text')
     assert writer.system_prompt == expected
     assert 'cats' in expected
 
@@ -229,6 +230,7 @@ def test_run_auto_requests_prompt(monkeypatch, tmp_path, capsys):
         iterations=2,
         config=cfg,
         content='about cats',
+        text_type='Essay',
     )
 
     calls = []
@@ -242,13 +244,14 @@ def test_run_auto_requests_prompt(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(
         prompts,
         'META_PROMPT',
-        'sentinel prompt {title} {content} {word_count} {current_text}',
+        'sentinel prompt {title} {text_type} {content} {word_count} {current_text}',
     )
     monkeypatch.setattr(writer, '_call_llm', fake_call_llm)
     writer.run_auto()
 
     out = capsys.readouterr().out
     assert any('sentinel prompt' in c for c in calls)
+    assert 'Essay' in calls[0]
     assert 'iteration 1/2' in out
     assert '[##########----------]' in out
     assert (tmp_path / 'output' / 'story.txt').exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,9 +17,13 @@ def test_cli_main(monkeypatch, tmp_path, capsys):
     captured_cfg = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(topic, word_count, steps, iterations, config, content=""):
+    def capturing_writer(
+        topic, word_count, steps, iterations, config, content="", text_type="Text"
+    ):
         captured_cfg['config'] = config
-        return original_writer(topic, word_count, steps, iterations, config, content=content)
+        return original_writer(
+            topic, word_count, steps, iterations, config, content=content, text_type=text_type
+        )
 
     monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
 
@@ -100,9 +104,13 @@ def test_cli_ollama_model_selection(monkeypatch, tmp_path, capsys):
     captured_cfg = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(topic, word_count, steps, iterations, config, content=""):
+    def capturing_writer(
+        topic, word_count, steps, iterations, config, content="", text_type="Text"
+    ):
         captured_cfg['config'] = config
-        return original_writer(topic, word_count, steps, iterations, config, content=content)
+        return original_writer(
+            topic, word_count, steps, iterations, config, content=content, text_type=text_type
+        )
 
     monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
 
@@ -174,14 +182,19 @@ def test_cli_defaults(monkeypatch, tmp_path, capsys):
     captured_args = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(topic, word_count, steps, iterations, config, content=""):
+    def capturing_writer(
+        topic, word_count, steps, iterations, config, content="", text_type="Text"
+    ):
         captured_args['topic'] = topic
         captured_args['word_count'] = word_count
         captured_args['steps'] = steps
         captured_args['iterations'] = iterations
         captured_args['config'] = config
         captured_args['content'] = content
-        return original_writer(topic, word_count, steps, iterations, config, content=content)
+        captured_args['text_type'] = text_type
+        return original_writer(
+            topic, word_count, steps, iterations, config, content=content, text_type=text_type
+        )
 
     monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
 
@@ -201,6 +214,7 @@ def test_cli_defaults(monkeypatch, tmp_path, capsys):
     assert cfg_used.temperature == cfg.temperature
     assert cfg_used.context_length == cfg.context_length
     assert cfg_used.max_tokens == cfg.max_tokens
+    assert captured_args['text_type'] == 'Text'
 
 
 def test_cli_auto_mode(monkeypatch, tmp_path, capsys):
@@ -214,17 +228,22 @@ def test_cli_auto_mode(monkeypatch, tmp_path, capsys):
     captured = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(topic, word_count, steps, iterations, config, content=""):
+    def capturing_writer(
+        topic, word_count, steps, iterations, config, content="", text_type="Text"
+    ):
         captured['topic'] = topic
         captured['content'] = content
         captured['iterations'] = iterations
         captured['steps'] = steps
         captured['config'] = config
-        return original_writer(topic, word_count, steps, iterations, config, content=content)
+        captured['text_type'] = text_type
+        return original_writer(
+            topic, word_count, steps, iterations, config, content=content, text_type=text_type
+        )
 
     monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
 
-    inputs = iter(['y', 'My Title', 'A cat story', '5', '2', 'stub', 'test-model'])
+    inputs = iter(['y', 'My Title', 'A cat story', 'Essay', '5', '2', 'stub', 'test-model'])
     monkeypatch.setattr('builtins.input', lambda _: next(inputs))
 
     cli.main()
@@ -235,6 +254,7 @@ def test_cli_auto_mode(monkeypatch, tmp_path, capsys):
     assert captured['steps'] == []
     assert captured['content'] == 'A cat story'
     assert captured['iterations'] == 2
+    assert captured['text_type'] == 'Essay'
     cfg_used = captured['config']
     assert cfg_used.llm_provider == 'stub'
     assert cfg_used.model == 'test-model'
@@ -251,14 +271,18 @@ def test_cli_auto_mode_openai_endpoint(monkeypatch, tmp_path, capsys):
     captured = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(topic, word_count, steps, iterations, config, content=""):
+    def capturing_writer(
+        topic, word_count, steps, iterations, config, content="", text_type="Text"
+    ):
         captured['config'] = config
-        return original_writer(topic, word_count, steps, iterations, config, content=content)
+        return original_writer(
+            topic, word_count, steps, iterations, config, content=content, text_type=text_type
+        )
 
     monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
 
     inputs = iter(
-        ['y', 'T', 'C', '5', '1', 'openai', 'gpt', 'http://custom']
+        ['y', 'T', 'C', 'Report', '5', '1', 'openai', 'gpt', 'http://custom']
     )
     monkeypatch.setattr('builtins.input', lambda _: next(inputs))
 

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -37,6 +37,7 @@ class WriterAgent:
         iterations: int,
         config: Config | None = None,
         content: str = "",
+        text_type: str = "Text",
     ) -> None:
         self.topic = topic
         self.word_count = word_count
@@ -44,13 +45,16 @@ class WriterAgent:
         self.iterations = iterations
         self.config = config or DEFAULT_CONFIG
         self.content = content
+        self.text_type = text_type
 
         self.config.ensure_dirs()
 
         # System prompt derived from the user's topic. This is attached to every
         # LLM request so that the model understands the overall context of the
         # writing task.
-        self.system_prompt = prompts.SYSTEM_PROMPT.format(topic=self.topic)
+        self.system_prompt = prompts.SYSTEM_PROMPT.format(
+            topic=self.topic, text_type=self.text_type
+        )
 
         logging.basicConfig(
             filename=self.config.log_dir / self.config.log_file,
@@ -127,6 +131,7 @@ class WriterAgent:
             current_text = " ".join(text)
             meta_prompt = prompts.META_PROMPT.format(
                 title=self.topic,
+                text_type=self.text_type,
                 content=self.content,
                 word_count=self.word_count,
                 current_text=current_text,
@@ -137,6 +142,7 @@ class WriterAgent:
             start = time.perf_counter()
             user_prompt = (
                 f"{prompt}\n\nTitel: {self.topic}\n"
+                f"Textart: {self.text_type}\n"
                 f"Gewünschter Inhalt: {self.content}\n"
                 f"Aktueller Text:\n{current_text}\n\nNächster Abschnitt:"
             )

--- a/wordsmith/cli.py
+++ b/wordsmith/cli.py
@@ -45,6 +45,7 @@ def _run_cli() -> None:
         default_topic = "Untitled"
         topic = input(f"Title [{default_topic}]: ").strip() or default_topic
         content = input("Desired content: ").strip()
+        text_type = input("Text type: ").strip() or "Text"
         word_count = _prompt_int("Word count [100]: ", default=100)
         iterations = _prompt_int("Number of iterations [1]: ", default=1)
 
@@ -113,6 +114,7 @@ def _run_cli() -> None:
             iterations,
             config=cfg,
             content=content,
+            text_type=text_type,
         )
         final_text = writer.run_auto()
 

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -2,13 +2,14 @@
 
 SYSTEM_PROMPT = (
     "Du bist eine erfahrene, kreative Autorin und Lektorin. "
-    "Du verfasst gut strukturierte und ansprechende Texte in klarem Deutsch. "
-    "Achte auf logische Übergänge, natürlichen Stil und vermeide Wiederholungen. Achte besonderes auf die inhaltliche Qualität des Textes. "
+    "Du verfasst gut strukturierte und ansprechende {text_type} in klarem Deutsch. "
+    "Achte auf logische Übergänge, natürlichen Stil und vermeide Wiederholungen. "
+    "Achte besonderes auf die inhaltliche Qualität des Textes. "
     "Dein Thema lautet: {topic}."
 )
 
 META_PROMPT = (
-    "Du arbeitest an einem Text mit dem Titel: {title}\n"
+    "Du arbeitest an einem {text_type} mit dem Titel: {title}\n"
     "Er behandelt folgenden Inhalt: {content}\n"
     "Die gewünschte Länge beträgt etwa {word_count} Wörter.\n"
     "Aktueller Stand des Textes:\n{current_text}\n\n"


### PR DESCRIPTION
## Summary
- Ask for desired text type in automatic CLI mode and forward it to the writing agent
- Include text type in system and meta prompts
- Extend tests for agent and CLI to cover the new text type parameter

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a43aa7cddc8325817f9b65bc15d7b1