### PR TITLE
Use predefined initial prompt in auto mode

### DIFF
--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -17,3 +17,11 @@ META_PROMPT = (
     "Formuliere ausschließlich einen präzisen Prompt für ein LLM, der diesen Schritt beschreibt."
 )
 
+INITIAL_AUTO_PROMPT = (
+    "Schreibe diesen Text.\n"
+    "Titel: {title}\n"
+    "Textart: {text_type}\n"
+    "Inhalt: {content}\n"
+    "Er soll etwa {word_count} Wörter umfassen."
+)
+


### PR DESCRIPTION
## Summary
- Start automatic mode with a fixed prompt based on title, text type, content, and word count
- Skip meta-prompting in the first iteration
- Expand tests for initial auto prompt handling and update existing scenarios

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a44cfb87408325ae4f26e2ccc072d1