### PR TITLE
Save auto iterations to separate files

### DIFF
--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -169,6 +169,7 @@ class WriterAgent:
             text.append(addition)
             current_text = " ".join(text)
             self._save_text(current_text)
+            self._save_iteration_text(current_text, iteration)
             self.logger.info(
                 "iteration %s/%s: %s", iteration, self.iterations, addition
             )
@@ -186,6 +187,7 @@ class WriterAgent:
         if len(words) > self.word_count:
             final_text = " ".join(words[: self.word_count])
         self._save_text(final_text)
+        self._save_iteration_text(final_text, self.iterations)
         return final_text
 
     # ------------------------------------------------------------------
@@ -273,6 +275,18 @@ class WriterAgent:
 
         self.llm_logger.info("response: %s", result)
         return result
+
+    # ------------------------------------------------------------------
+    def _save_iteration_text(self, text: str, iteration: int) -> None:
+        """Persist ``text`` of the current iteration to a separate file."""
+
+        filename = self.config.auto_iteration_file_template.format(iteration)
+        path = self.config.output_dir / filename
+        self.config.output_dir.mkdir(exist_ok=True)
+        with path.open("w", encoding="utf8") as fh:
+            fh.write(text + "\n")
+            fh.flush()
+            os.fsync(fh.fileno())
 
     # ------------------------------------------------------------------
     def _save_text(self, text: str) -> None:

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -13,6 +13,7 @@ class Config:
     log_dir: Path = Path("logs")
     output_dir: Path = Path("output")
     output_file: str = "current_text.txt"
+    auto_iteration_file_template: str = "iteration_{:02d}.txt"
     log_level: int = logging.INFO
     log_file: str = "run.log"
     llm_log_file: str = "llm.log"

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -13,7 +13,7 @@ META_PROMPT = (
     "Er behandelt folgenden Inhalt: {content}\n"
     "Die gewünschte Länge beträgt etwa {word_count} Wörter.\n"
     "Aktueller Stand des Textes:\n{current_text}\n\n"
-    "Bestimme den nächsten sinnvollen erzählerischen Schritt, um die Geschichte spannender, "
+    "Bestimme den nächsten sinnvollen Schritt, um die Geschichte spannender, "
     "atmosphärischer oder emotional tiefer zu machen. "
     "Lege dabei Wert auf Figurenentwicklung, Spannung, Konflikte oder überraschende Wendungen. "
     "Formuliere ausschließlich einen präzisen Prompt für ein LLM, der diesen erzählerischen Schritt beschreibt."


### PR DESCRIPTION
## Summary
- add `auto_iteration_file_template` setting for naming per-iteration outputs
- write each automatic-mode iteration to its own file
- adjust META_PROMPT wording to include "nächsten sinnvollen Schritt"
- test per-iteration file creation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a460b59e7c8325917eb3011f15a9f4