### PR TITLE
Fix logging encoding and update defaults

### DIFF
--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -57,10 +57,11 @@ class WriterAgent:
         )
 
         logging.basicConfig(
-            filename=self.config.log_dir / self.config.log_file,
+            filename=str(self.config.log_dir / self.config.log_file),
             level=self.config.log_level,
             format="%(asctime)s - %(message)s",
             encoding=self.config.log_encoding,
+            errors="backslashreplace",
             force=True,
         )
         self.logger = logging.getLogger(__name__)
@@ -68,6 +69,7 @@ class WriterAgent:
         llm_handler = logging.FileHandler(
             self.config.log_dir / self.config.llm_log_file,
             encoding=self.config.log_encoding,
+            errors="backslashreplace",
         )
         llm_handler.setFormatter(logging.Formatter("%(asctime)s - %(message)s"))
         llm_handler.setLevel(self.config.log_level)

--- a/wordsmith/cli.py
+++ b/wordsmith/cli.py
@@ -124,7 +124,7 @@ def _run_cli() -> None:
 
     default_topic = "Untitled"
     topic = input(f"Topic [{default_topic}]: ").strip() or default_topic
-    word_count = _prompt_int("Word count [250]: ", default=250)
+    word_count = _prompt_int("Word count [100]: ", default=100)
     step_count = _prompt_int("Number of steps [1]: ", default=1)
     iterations = _prompt_int("Iterations per step [1]: ", default=1)
 

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -21,10 +21,10 @@ class Config:
     llm_provider: str = "stub"
     model: str = "gpt-3.5-turbo"
     temperature: float = 0.7
-    context_length: int = 4096
-    max_tokens: int = 4096
-    auto_ctx_multiplier: int = 8
-    auto_token_multiplier: int = 4
+    context_length: int = 2048
+    max_tokens: int = 256
+    auto_ctx_multiplier: int = 4
+    auto_token_multiplier: int = 2
     openai_api_key: str | None = None
     openai_url: str = "https://api.openai.com/v1/chat/completions"
     ollama_url: str = "http://192.168.100.148:11434/api/generate"

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -13,12 +13,12 @@ META_PROMPT = (
     "Er behandelt folgenden Inhalt: {content}\n"
     "Die gewünschte Länge beträgt etwa {word_count} Wörter.\n"
     "Aktueller Stand des Textes:\n{current_text}\n\n"
-    "Überlege nun, welcher nächste erzählerische Schritt den Text literarisch vertiefen würde. "
+    "Beschreibe den nächsten sinnvollen Schritt der Geschichte, der den Text literarisch vertiefen würde. "
     "Achte darauf, dass Atmosphäre, Spannung und innere Konflikte verstärkt werden und die Figuren "
     "lebendiger, widersprüchlicher und psychologisch nachvollziehbarer wirken. "
     "Lege Wert auf subtile Andeutungen, emotionale Zwischentöne und mögliche symbolische Elemente, "
     "die den Text dichter und vielschichtiger machen. "
-    "Formuliere ausschließlich einen präzisen Prompt für ein LLM, der genau diesen nächsten Schritt beschreibt, "
+    "Formuliere ausschließlich einen präzisen Prompt für ein LLM, der genau diesen nächsten sinnvollen Schritt beschreibt, "
     "so dass daraus eine kreative und literarisch hochwertige Erweiterung der Geschichte entstehen kann."
 )
 


### PR DESCRIPTION
## Summary
- ensure log files always use UTF-8 encoding and replace unencodable characters
- update default context/token limits and CLI word count
- include clear next-step phrase in meta prompt

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4819d6564832585b790075b7bfb1b