### PR TITLE
feat: structure llm log as json

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4,6 +4,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import json
 import urllib.request
 import urllib.error
+from datetime import datetime
 
 import wordsmith.agent as agent
 from wordsmith import prompts
@@ -140,9 +141,12 @@ def test_call_llm_logs_prompt_and_response(tmp_path):
     assert result == 'hello'
     log_path = tmp_path / 'logs' / cfg.llm_log_file
     assert log_path.exists()
-    content = log_path.read_text(encoding='utf-8')
-    assert 'say hi' in content
-    assert 'hello' in content
+    content = log_path.read_text(encoding='utf-8').strip().splitlines()
+    entries = [json.loads(line) for line in content]
+    assert any(e["event"] == "prompt" and 'say hi' in e["text"] for e in entries)
+    assert any(e["event"] == "response" and e["text"] == 'hello' for e in entries)
+    for e in entries:
+        datetime.fromisoformat(e["time"])
 
 
 def test_default_meta_prompt_contains_next_step_phrase():

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,7 @@
 import sys, pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
+import json
 import wordsmith.agent as agent
 from wordsmith.config import Config
 
@@ -9,13 +10,15 @@ def test_logs_use_utf8(tmp_path):
     cfg = Config(log_dir=tmp_path / "logs", output_dir=tmp_path / "out")
     writer = agent.WriterAgent("topic", 5, [], iterations=1, config=cfg)
     writer.logger.info("unicode \u2713")
-    writer.llm_logger.info("prompt: \u4f60\u597d")
+    writer.llm_logger.info(json.dumps({"event": "prompt", "text": "\u4f60\u597d"}, ensure_ascii=False))
     run_data = (cfg.log_dir / cfg.log_file).read_bytes()
     llm_data = (cfg.log_dir / cfg.llm_log_file).read_bytes()
     for data, expected in [
         (run_data, "unicode \u2713"),
-        (llm_data, "prompt: \u4f60\u597d"),
+        (llm_data, "\u4f60\u597d"),
     ]:
         assert b"\x00" not in data
         text = data.decode("utf-8")
         assert expected in text
+    # Ensure llm log is valid JSON
+    json.loads(llm_data.decode("utf-8").splitlines()[0])


### PR DESCRIPTION
## Summary
- log LLM prompts and responses as JSON lines for easier parsing
- record ISO-8601 timestamps for each prompt and response
- test JSON log formatting, including timestamp parsing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a49f135b548325b04605b306e6130b