### PR TITLE
Centralize prompt templates

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -192,15 +192,14 @@ def test_run_uses_crafted_prompt(monkeypatch, tmp_path):
     def fake_call_llm(prompt, fallback):
         calls.append(prompt)
         # First call crafts the prompt, second generates text
-        if 'Formuliere einen klaren und konkreten Prompt' in prompt:
-            return 'Write about cats.'
-        return 'Some text.'
+        return 'Write about cats.' if len(calls) == 1 else 'Some text.'
 
     monkeypatch.setattr(writer, '_call_llm', fake_call_llm)
     writer.run()
-
-    assert any('Formuliere einen klaren und konkreten Prompt' in c for c in calls)
-    assert any('Aktueller Text:' in c for c in calls)
+    expected_meta = prompts.PROMPT_CRAFTING_PROMPT.format(task='intro', topic='cats')
+    expected_user = prompts.STEP_PROMPT.format(prompt='Write about cats.', current_text='')
+    assert calls[0] == expected_meta
+    assert calls[1] == expected_user
 
 
 def test_run_reports_progress(monkeypatch, tmp_path, capsys):

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -214,10 +214,8 @@ class WriterAgent:
     def _craft_prompt(self, task: str) -> str:
         """Ask the LLM to craft an optimal prompt for the given task."""
 
-        meta_prompt = (
-            f"Formuliere einen klaren und konkreten Prompt für ein LLM, "
-            f"um die Aufgabe '{task}' zum Thema '{self.topic}' umzusetzen. "
-            f"Gib nur den Prompt zurück."
+        meta_prompt = prompts.PROMPT_CRAFTING_PROMPT.format(
+            task=task, topic=self.topic
         )
         fallback = f"{task} über {self.topic}"
         return self._call_llm(meta_prompt, fallback=fallback)
@@ -226,8 +224,8 @@ class WriterAgent:
     def _generate(self, prompt: str, current_text: str, iteration: int) -> str:
         """Generate text for ``prompt`` given the current text state."""
 
-        user_prompt = (
-            f"{prompt}\n\nAktueller Text:\n{current_text}\n\nNächster Abschnitt:"
+        user_prompt = prompts.STEP_PROMPT.format(
+            prompt=prompt, current_text=current_text
         )
         fallback = f"{prompt}. (Iteration {iteration})"
         return self._call_llm(user_prompt, fallback=fallback)

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -56,4 +56,16 @@ REVISION_PROMPT = (
 )
 
 
+PROMPT_CRAFTING_PROMPT = (
+    "Formuliere einen klaren und konkreten Prompt für ein LLM, "
+    "um die Aufgabe '{task}' zum Thema '{topic}' umzusetzen. "
+    "Gib nur den Prompt zurück."
+)
+
+
+STEP_PROMPT = (
+    "{prompt}\n\nAktueller Text:\n{current_text}\n\nNächster Abschnitt:"
+)
+
+
 


### PR DESCRIPTION
## Summary
- move prompt crafting and step prompts to `prompts.py` for centralized management
- use new prompt templates in `WriterAgent`
- adapt tests to expect the centralized prompts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4c37fa7d8832597624b438954e80c