### PR TITLE
docs: add prompt file guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,5 @@ Guidelines for coding agents working on this repository:
 - Generated artifacts like logs/ and output/ are ignored by git.
 - Store application settings in `wordsmith/config.py` rather than
   scattering them throughout the codebase.
+
+- Keep prompts in `wordsmith/prompts.py` instead of inlining them elsewhere.


### PR DESCRIPTION
## Summary
- clarify that prompts should live in `wordsmith/prompts.py`
## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4c7b9bd1883259c27ebb9d34343db