### PR TITLE
Save draft iteration in automatic mode

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -369,6 +369,11 @@ def test_run_auto_writes_iteration_files(monkeypatch, tmp_path):
     monkeypatch.setattr(writer, '_call_llm', fake_call_llm)
 
     writer.run_auto()
-
-    iter1 = (tmp_path / 'output' / cfg.auto_iteration_file_template.format(1)).read_text(encoding='utf-8').strip()
+    iter0 = (
+        tmp_path / 'output' / cfg.auto_iteration_file_template.format(0)
+    ).read_text(encoding='utf-8').strip()
+    iter1 = (
+        tmp_path / 'output' / cfg.auto_iteration_file_template.format(1)
+    ).read_text(encoding='utf-8').strip()
+    assert iter0 == 'draft'
     assert iter1 == 'edited'

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -171,6 +171,7 @@ class WriterAgent:
         if len(words_list) > self.word_count:
             final_text = " ".join(words_list[: self.word_count])
         self._save_text(final_text)
+        self._save_iteration_text(final_text, 0)
 
         for iteration in range(1, self.iterations + 1):
             revision_prompt = prompts.REVISION_PROMPT.format(


### PR DESCRIPTION
## Summary
- ensure `run_auto` persists the initial draft to `iteration_00.txt`
- test that automatic mode writes both draft and edited versions to iteration files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a55386dfbc8325990ba0f9eb85a466