### PR TITLE
Save outline as iteration zero

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -375,5 +375,9 @@ def test_run_auto_writes_iteration_files(monkeypatch, tmp_path):
     iter1 = (
         tmp_path / 'output' / cfg.auto_iteration_file_template.format(1)
     ).read_text(encoding='utf-8').strip()
-    assert iter0 == 'draft'
-    assert iter1 == 'edited'
+    iter2 = (
+        tmp_path / 'output' / cfg.auto_iteration_file_template.format(2)
+    ).read_text(encoding='utf-8').strip()
+    assert iter0 == '1. Part (5)'
+    assert iter1 == 'draft'
+    assert iter2 == 'edited'

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -139,6 +139,7 @@ class WriterAgent:
             fallback="1. Einleitung (100)",
             system_prompt=prompts.OUTLINE_SYSTEM_PROMPT,
         )
+        self._save_iteration_text(outline, 0)
         sections = self._parse_outline(outline)
 
         for idx, (title, words) in enumerate(sections, start=1):
@@ -171,7 +172,7 @@ class WriterAgent:
         if len(words_list) > self.word_count:
             final_text = " ".join(words_list[: self.word_count])
         self._save_text(final_text)
-        self._save_iteration_text(final_text, 0)
+        self._save_iteration_text(final_text, 1)
 
         for iteration in range(1, self.iterations + 1):
             revision_prompt = prompts.REVISION_PROMPT.format(
@@ -193,7 +194,7 @@ class WriterAgent:
             tok_per_sec = tokens / (elapsed or 1e-8)
             final_text = revised
             self._save_text(final_text)
-            self._save_iteration_text(final_text, iteration)
+            self._save_iteration_text(final_text, iteration + 1)
             bar_len = 20
             filled = int(bar_len * iteration / self.iterations)
             bar = "#" * filled + "-" * (bar_len - filled)


### PR DESCRIPTION
## Summary
- Persist the generated outline to iteration_00.txt
- Shift automatic drafting and revision files up one index
- Adjust tests for new iteration numbering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a57020c234832598869fa14ff98c78