### PR TITLE
Handle bullet subpoints in outline parsing

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -341,7 +341,7 @@ def test_run_auto_sets_token_limits(monkeypatch, tmp_path):
 def test_parse_outline(tmp_path):
     cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'out')
     writer = agent.WriterAgent('T', 10, [], iterations=0, config=cfg)
-    outline = '1. Intro (3)\n2. Body (5)'
+    outline = '1. Intro (3)\n    * detail\n2. Body (5)\n    * more detail'
     assert writer._parse_outline(outline) == [('Intro', 3), ('Body', 5)]
 
 

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -224,9 +224,11 @@ class WriterAgent:
         sections: List[Tuple[str, int]] = []
         for line in outline.splitlines():
             line = line.strip()
-            if not line:
+            if not line or line.startswith(('*', '-', '+')):
                 continue
-            line = line.split(".", 1)[-1].strip() if "." in line else line
+            if not re.match(r"\d+\.", line):
+                continue
+            line = line.split(".", 1)[1].strip()
             match = re.search(r"^(.*?)(?:\((\d+)[^)]*\))?$", line)
             if match:
                 title = match.group(1).strip()


### PR DESCRIPTION
## Summary
- Ignore bullet subpoints when parsing outlines to prevent duplicate section generation
- Add regression test covering outlines with bullet subpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5867a07c4832596450247fe72dea7