### PR TITLE
Add text type check in automatic mode

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -277,6 +277,7 @@ def test_run_auto_generates_outline_and_sections(monkeypatch, tmp_path):
             '1. Intro (5)\n2. End (5)',
             'intro text',
             'end text',
+            'check',
             'edited text',
         ]
     )
@@ -300,8 +301,10 @@ def test_run_auto_generates_outline_and_sections(monkeypatch, tmp_path):
     assert calls[1][1] == prompts.SECTION_SYSTEM_PROMPT
     assert 'Schreibe den Abschnitt' in calls[2][0]
     assert calls[2][1] == prompts.SECTION_SYSTEM_PROMPT
-    assert 'Überarbeite den folgenden' in calls[3][0]
-    assert calls[3][1] == prompts.REVISION_SYSTEM_PROMPT
+    assert 'Prüfe, ob der folgende Text' in calls[3][0]
+    assert calls[3][1] == prompts.TEXT_TYPE_CHECK_SYSTEM_PROMPT
+    assert 'Überarbeite den folgenden' in calls[4][0]
+    assert calls[4][1] == prompts.REVISION_SYSTEM_PROMPT
     assert saved[0] == 'intro text'
     assert saved[1] == 'intro text end text'
     assert saved[-1] == 'edited text'
@@ -361,7 +364,7 @@ def test_run_auto_writes_iteration_files(monkeypatch, tmp_path):
         content='about cats',
     )
 
-    responses = iter(['1. Part (5)', 'draft', 'edited'])
+    responses = iter(['1. Part (5)', 'draft', 'check', 'edited'])
 
     def fake_call_llm(prompt, fallback, *, system_prompt=None):
         return next(responses)
@@ -403,6 +406,7 @@ def test_run_auto_skips_duplicate_sections_and_revisions(monkeypatch, tmp_path):
         '1. Part (5)\n2. Second (5)',
         'dup',
         'dup',
+        'check',
         'dup',
     ])
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -10,6 +10,7 @@ def test_prompts_have_system_prompts():
     assert prompts.REVISION_SYSTEM_PROMPT.strip()
     assert prompts.PROMPT_CRAFTING_SYSTEM_PROMPT.strip()
     assert prompts.STEP_SYSTEM_PROMPT.strip()
+    assert prompts.TEXT_TYPE_CHECK_SYSTEM_PROMPT.strip()
 
 
 def test_system_prompts_quality_phrases():
@@ -21,3 +22,4 @@ def test_system_prompts_quality_phrases():
     assert "Stil, Kohärenz und Grammatik" in prompts.REVISION_SYSTEM_PROMPT
     assert "vermeidest Mehrdeutigkeiten" in prompts.PROMPT_CRAFTING_SYSTEM_PROMPT
     assert "Figuren, Ton und Spannung" in prompts.STEP_SYSTEM_PROMPT
+    assert "Merkmalen der angegebenen Textart" in prompts.TEXT_TYPE_CHECK_SYSTEM_PROMPT

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -180,6 +180,18 @@ class WriterAgent:
             last_saved = final_text
         self._save_iteration_text(final_text, 1)
 
+        check_prompt = prompts.TEXT_TYPE_CHECK_PROMPT.format(
+            text_type=self.text_type,
+            current_text=final_text,
+        )
+        check_result = self._call_llm(
+            check_prompt,
+            fallback="",
+            system_prompt=prompts.TEXT_TYPE_CHECK_SYSTEM_PROMPT,
+        )
+        self.logger.info("text type check: %s", check_result)
+        print(f"text type check: {check_result}", flush=True)
+
         for iteration in range(1, self.iterations + 1):
             revision_prompt = prompts.REVISION_PROMPT.format(
                 title=self.topic,

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -94,4 +94,14 @@ STEP_PROMPT = (
 )
 
 
+TEXT_TYPE_CHECK_SYSTEM_PROMPT = (
+    "Du prüfst Texte darauf, ob sie den Merkmalen der angegebenen Textart entsprechen."
+)
+TEXT_TYPE_CHECK_PROMPT = (
+    "Prüfe, ob der folgende Text die Anforderungen der Textart {text_type} erfüllt. "
+    "Antworte knapp mit Ja oder Nein und einer kurzen Begründung.\n\n"
+    "Text:\n{current_text}\n"
+)
+
+
 


### PR DESCRIPTION
## Summary
- add dedicated text type compliance check after initial draft generation
- introduce prompts for text type verification
- update tests for new check step

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5995734448325826c82598d65d16e