### PR TITLE
Enhance auto section prompt clarity

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -23,3 +23,8 @@ def test_system_prompts_quality_phrases():
     assert "vermeidest Mehrdeutigkeiten" in prompts.PROMPT_CRAFTING_SYSTEM_PROMPT
     assert "Figuren, Ton und Spannung" in prompts.STEP_SYSTEM_PROMPT
     assert "Merkmalen der angegebenen Textart" in prompts.TEXT_TYPE_CHECK_SYSTEM_PROMPT
+
+
+def test_section_prompt_mentions_text_type():
+    assert "Textart: {text_type}" in prompts.SECTION_PROMPT
+    assert "Anforderungen und Konventionen der Textart" in prompts.SECTION_PROMPT

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -150,6 +150,7 @@ class WriterAgent:
                 current_text=current_text,
                 title=title,
                 word_count=words or 0,
+                text_type=self.text_type,
             )
             start = time.perf_counter()
             addition = self._call_llm(

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -58,7 +58,9 @@ SECTION_SYSTEM_PROMPT = (
 SECTION_PROMPT = (
     "Outline:\n{outline}\n\n"
     "Bisheriger Text:\n{current_text}\n\n"
-    "Schreibe den Abschnitt '{title}' mit mindesten {word_count} Wörtern."
+    "Textart: {text_type}\n"
+    "Schreibe den Abschnitt '{title}' mit mindesten {word_count} Wörtern. "
+    "Achte darauf, dass der Abschnitt die Anforderungen und Konventionen der Textart {text_type} erfüllt. "
     "Schreibe nur diesen Abschnitt."
 )
 


### PR DESCRIPTION
## Summary
- Ensure automatic section generation explicitly accounts for the desired text type
- Pass text type information to section prompt during auto mode
- Test that section prompt references text type requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5b458407c8325a18b10eca0835390