### PR TITLE
Clarify text type requirements in meta prompt

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -28,3 +28,7 @@ def test_system_prompts_quality_phrases():
 def test_section_prompt_mentions_text_type():
     assert "Textart: {text_type}" in prompts.SECTION_PROMPT
     assert "Anforderungen und Konventionen der Textart" in prompts.SECTION_PROMPT
+
+
+def test_meta_prompt_mentions_text_type_requirements():
+    assert "Anforderungen und Konventionen der Textart" in prompts.META_PROMPT

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -20,6 +20,7 @@ META_PROMPT = (
     "Beschreibe den nächsten sinnvollen Schritt der Geschichte, der den Text literarisch vertiefen würde. "
     "Achte darauf, dass Atmosphäre, Spannung und innere Konflikte verstärkt werden und die Figuren "
     "lebendiger, widersprüchlicher und psychologisch nachvollziehbarer wirken. "
+    "Berücksichtige die spezifischen Anforderungen und Konventionen der Textart {text_type}. "
     "Lege Wert auf subtile Andeutungen, emotionale Zwischentöne und mögliche symbolische Elemente, "
     "die den Text dichter und vielschichtiger machen. "
     "Formuliere ausschließlich einen präzisen Prompt für ein LLM, der genau diesen nächsten sinnvollen Schritt beschreibt, "


### PR DESCRIPTION
## Summary
- emphasize adherence to text type conventions in the meta prompt used during automatic mode
- add regression test ensuring meta prompt references text type requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5bc4c8aec8325b13cf0a4eae036cd