### PR TITLE
Add character descriptions to outline prompt

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -344,7 +344,12 @@ def test_run_auto_sets_token_limits(monkeypatch, tmp_path):
 def test_parse_outline(tmp_path):
     cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'out')
     writer = agent.WriterAgent('T', 10, [], iterations=0, config=cfg)
-    outline = '1. Intro (3)\n    * detail\n2. Body (5)\n    * more detail'
+    outline = (
+        '1. Intro (3)\n    * detail\n'
+        '2. Body (5)\n    * more detail\n'
+        '# Alice: neugierige Heldin\n'
+        '# Bob: weiser Mentor'
+    )
     assert writer._parse_outline(outline) == [('Intro', 3), ('Body', 5)]
 
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -28,3 +28,13 @@ def test_system_prompts_quality_phrases():
 def test_section_prompt_mentions_text_type():
     assert "Textart: {text_type}" in prompts.SECTION_PROMPT
     assert "Anforderungen und Konventionen der Textart" in prompts.SECTION_PROMPT
+
+
+def test_outline_prompt_mentions_character_lines():
+    text = prompts.OUTLINE_PROMPT.format(
+        text_type='Roman',
+        title='Titel',
+        content='Inhalt',
+        word_count=100,
+    )
+    assert 'Jede Zeile beginnt mit #' in text

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -237,7 +237,7 @@ class WriterAgent:
         sections: List[Tuple[str, int]] = []
         for line in outline.splitlines():
             line = line.strip()
-            if not line or line.startswith(('*', '-', '+')):
+            if not line or line.startswith(('*', '-', '+', '#')):
                 continue
             if not re.match(r"\d+\.", line):
                 continue

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -48,7 +48,9 @@ OUTLINE_PROMPT = (
     "Erstelle eine gegliederte Outline für einen {text_type} mit dem Titel: {title}\n"
     "Der Text behandelt folgenden Inhalt: {content}\n"
     "Die Gesamtlänge beträgt etwa {word_count} Wörter.\n"
-    "Gib eine nummerierte Liste der Abschnitte zurück und vermerke in Klammern den ungefähren Wortumfang jedes Abschnitts."
+    "Gib eine nummerierte Liste der Abschnitte zurück und vermerke in Klammern den ungefähren Wortumfang jedes Abschnitts.\n"
+    "Füge am Ende eine Liste aller Figuren hinzu, die vorkommen sollen. "
+    "Jede Zeile beginnt mit # und enthält eine kurze Charakterisierung."
 )
 
 SECTION_SYSTEM_PROMPT = (


### PR DESCRIPTION
## Summary
- Extend outline prompt to request a character list with '#' prefixed descriptions
- Ignore character description lines when parsing outlines
- Cover new prompt behavior with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5bef08d388325b3999d3434d15fad