### PR TITLE
Add idea refinement step before outlining

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -5,6 +5,7 @@ def test_prompts_have_system_prompts():
     assert prompts.SYSTEM_PROMPT.strip()
     assert prompts.META_SYSTEM_PROMPT.strip()
     assert prompts.INITIAL_AUTO_SYSTEM_PROMPT.strip()
+    assert prompts.IDEA_IMPROVEMENT_SYSTEM_PROMPT.strip()
     assert prompts.OUTLINE_SYSTEM_PROMPT.strip()
     assert prompts.OUTLINE_IMPROVEMENT_SYSTEM_PROMPT.strip()
     assert prompts.SECTION_SYSTEM_PROMPT.strip()
@@ -18,6 +19,7 @@ def test_system_prompts_quality_phrases():
     assert "Vermeide Wiederholungen und Füllwörter" in prompts.SYSTEM_PROMPT
     assert "strukturierter Schreibcoach" in prompts.META_SYSTEM_PROMPT
     assert "hochwertigen ersten Rohtext" in prompts.INITIAL_AUTO_SYSTEM_PROMPT
+    assert "Rechtschreib- und Grammatikfehler" in prompts.IDEA_IMPROVEMENT_SYSTEM_PROMPT
     assert "klare Hierarchien" in prompts.OUTLINE_SYSTEM_PROMPT
     assert "Charakterisierung der Figuren" in prompts.OUTLINE_IMPROVEMENT_SYSTEM_PROMPT
     assert "konsistent im Stil" in prompts.SECTION_SYSTEM_PROMPT

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -127,7 +127,12 @@ class WriterAgent:
 
         text: List[str] = []
         self.config.adjust_for_word_count(self.word_count)
-
+        idea_prompt = prompts.IDEA_IMPROVEMENT_PROMPT.format(content=self.content)
+        self.content = self._call_llm(
+            idea_prompt,
+            fallback=self.content,
+            system_prompt=prompts.IDEA_IMPROVEMENT_SYSTEM_PROMPT,
+        )
         outline_prompt = prompts.OUTLINE_PROMPT.format(
             title=self.topic,
             text_type=self.text_type,

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -40,6 +40,17 @@ INITIAL_AUTO_PROMPT = (
     "Beachte die Konventionen der Textart {text_type}.\n"
 )
 
+IDEA_IMPROVEMENT_SYSTEM_PROMPT = (
+    "Du überarbeitest Ideen, korrigierst Rechtschreib- und Grammatikfehler und formulierst sie klarer. "
+    "Wenn sinnvoll, ergänzt du ein oder zwei originelle Aspekte."
+)
+IDEA_IMPROVEMENT_PROMPT = (
+    "Überarbeite die folgende Idee.\n"
+    "Korrigiere Rechtschreib- und Grammatikfehler, formuliere sie prägnanter und ergänze, "
+    "falls passend, ein oder zwei originelle Aspekte.\n\n"
+    "Idee:\n{content}\n"
+)
+
 OUTLINE_SYSTEM_PROMPT = (
     "Du gliederst Themen in übersichtliche, gut strukturierte Outlines und achtest auf klare Hierarchien "
     "sowie eine sinnvolle Reihenfolge."


### PR DESCRIPTION
## Summary
- polish user-provided idea before outlining in automatic mode
- add dedicated prompts for idea refinement
- cover idea improvement with new and updated tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5eca939d48325affc1580ab39efa2