### PR TITLE
Ensure outline subpoints use asterisks

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -46,6 +46,16 @@ def test_outline_prompt_mentions_character_lines():
     assert 'Jede Zeile beginnt mit #' in text
 
 
+def test_outline_prompt_enforces_subpoint_asterisks():
+    text = prompts.OUTLINE_PROMPT.format(
+        text_type='Roman',
+        title='Titel',
+        content='Inhalt',
+        word_count=100,
+    )
+    assert 'Unterpunkte müssen mit * beginnen' in text
+
+
 def test_text_type_fix_prompt_mentions_issues():
     text = prompts.TEXT_TYPE_FIX_PROMPT.format(
         issues='Fehler',

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -59,6 +59,7 @@ OUTLINE_PROMPT = (
     "Erstelle eine gegliederte Outline für einen {text_type} mit dem Titel: {title}\n"
     "Der Text behandelt folgenden Inhalt: {content}\n"
     "Die Gesamtlänge beträgt etwa {word_count} Wörter.\n"
+    "Alle Unterpunkte müssen mit * beginnen.\n"
     "Gib eine nummerierte Liste der Abschnitte zurück und vermerke in Klammern den ungefähren Wortumfang jedes Abschnitts.\n"
     "Füge am Ende eine Liste aller Figuren hinzu, die vorkommen sollen. "
     "Jede Zeile beginnt mit # und enthält eine kurze Charakterisierung."


### PR DESCRIPTION
## Summary
- require outline generator to start all subpoints with `*`
- test outline prompt for asterisk requirement

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6b4c257c48325b300f6b5d6657666