### PR TITLE
Ensure all outline sections are written to disk

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -315,7 +315,7 @@ def test_run_auto_generates_outline_and_sections(monkeypatch, tmp_path):
     assert 'Überarbeite den folgenden' in calls[7][0]
     assert calls[7][1] == prompts.REVISION_SYSTEM_PROMPT
     assert saved[0] == 'intro text'
-    assert saved[1] == 'intro text end text'
+    assert saved[1] == 'intro text\n\nend text'
     assert saved[-1] == 'edited text'
 
 
@@ -484,7 +484,7 @@ def test_run_auto_keeps_full_text_if_fix_is_incomplete(monkeypatch, tmp_path):
     iter1 = (
         tmp_path / 'output' / cfg.auto_iteration_file_template.format(1)
     ).read_text(encoding='utf-8').strip()
-    assert iter1 == 'intro text body text'
+    assert iter1 == 'intro text\n\nbody text'
 
 
 def test_run_auto_saves_draft_before_fix(monkeypatch, tmp_path):

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -181,7 +181,7 @@ class WriterAgent:
             tok_per_sec = tokens / (elapsed or 1e-8)
             if not text or addition.strip() != text[-1].strip():
                 text.append(addition)
-                current_text = " ".join(text)
+                current_text = "\n\n".join(text)
                 if current_text != last_saved:
                     self._save_text(current_text)
                     last_saved = current_text
@@ -190,7 +190,7 @@ class WriterAgent:
                 flush=True,
             )
 
-        final_text = " ".join(text)
+        final_text = "\n\n".join(text)
         words_list = final_text.split()
         if len(words_list) > self.word_count:
             final_text = " ".join(words_list[: self.word_count])


### PR DESCRIPTION
## Summary
- Write auto-generated sections separated by blank lines so each section is persisted
- Update tests to expect newline separated sections

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a858ebc6388325a573deddba04f033