### PR TITLE
Ensure outline is saved to file

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -319,6 +319,50 @@ def test_run_auto_generates_outline_and_sections(monkeypatch, tmp_path):
     assert saved[-1] == 'edited text'
 
 
+def test_run_auto_saves_outline(monkeypatch, tmp_path):
+    cfg = Config(
+        log_dir=tmp_path / 'logs',
+        output_dir=tmp_path / 'output',
+        output_file='story.txt',
+        outline_file='outline.txt',
+    )
+
+    writer = agent.WriterAgent(
+        'Title',
+        10,
+        [],
+        iterations=1,
+        config=cfg,
+        content='about cats',
+        text_type='Essay',
+    )
+
+    responses = iter(
+        [
+            'idea',
+            '1. Intro (5)\n2. End (5)',
+            '1. Intro (5)\n2. End (5) improved',
+            'intro text',
+            'end text',
+            'check',
+            'fixed text',
+            'edited text',
+        ]
+    )
+
+    monkeypatch.setattr(writer, '_call_llm', lambda *args, **kwargs: next(responses))
+    monkeypatch.setattr(writer, '_save_text', lambda text: None)
+
+    writer.run_auto()
+
+    outline_path = cfg.output_dir / cfg.outline_file
+    assert outline_path.exists()
+    assert (
+        outline_path.read_text(encoding='utf8')
+        == '1. Intro (5)\n2. End (5) improved\n'
+    )
+
+
 def test_run_auto_sets_token_limits(monkeypatch, tmp_path):
     cfg = Config(
         log_dir=tmp_path / 'logs',

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -156,6 +156,7 @@ class WriterAgent:
             system_prompt=prompts.OUTLINE_IMPROVEMENT_SYSTEM_PROMPT,
         )
         outline = self._clean_outline(outline)
+        self._save_outline(outline)
         self._save_iteration_text(outline, 0)
         sections = self._parse_outline(outline)
 
@@ -456,6 +457,17 @@ class WriterAgent:
             if prev_path.exists():
                 return prev_path.read_text(encoding="utf8").rstrip("\n")
         return ""
+
+    # ------------------------------------------------------------------
+    def _save_outline(self, outline: str) -> None:
+        """Persist the generated outline to a dedicated file."""
+
+        path = self.config.output_dir / self.config.outline_file
+        self.config.output_dir.mkdir(exist_ok=True)
+        with path.open("w", encoding="utf8") as fh:
+            fh.write(outline + "\n")
+            fh.flush()
+            os.fsync(fh.fileno())
 
     # ------------------------------------------------------------------
     def _save_text(self, text: str) -> None:

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -13,6 +13,7 @@ class Config:
     log_dir: Path = Path("logs")
     output_dir: Path = Path("output")
     output_file: str = "current_text.txt"
+    outline_file: str = "outline.txt"
     auto_iteration_file_template: str = "iteration_{:02d}.txt"
     log_level: int = logging.INFO
     log_file: str = "run.log"


### PR DESCRIPTION
## Summary
- Save generated outline to a dedicated outline file before parsing
- Add `outline_file` configuration option
- Test that automatic runs write the outline file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9bff82ffc83259962d1b6975c7d0f