### PR TITLE
Limit iteration context to last output

### DIFF
--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -92,15 +92,16 @@ class WriterAgent:
             # Ask the LLM for an optimal prompt for this step before running any
             # iterations.
             prompt = self._craft_prompt(step.task)
+            previous = ""
             for iteration in range(1, self.iterations + 1):
                 self.iteration = iteration
-                current_text = " ".join(text)
                 start = time.perf_counter()
-                addition = self._generate(prompt, current_text, iteration)
+                addition = self._generate(prompt, previous, iteration)
                 elapsed = time.perf_counter() - start
                 tokens = len(addition.split())
                 tok_per_sec = tokens / (elapsed or 1e-8)
                 text.append(addition)
+                previous = addition
                 current_text = " ".join(text)
                 self._save_text(current_text)
                 self.logger.info(


### PR DESCRIPTION
## Summary
- update `WriterAgent` to send only the previous iteration's text as context when generating new content
- expand unit test to verify each iteration only receives the last output plus the crafted prompt

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9cc71038c8325916f530cb217c246