### PR TITLE
feat: double auto token limit

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -456,7 +456,7 @@ def test_run_auto_sets_token_limits(monkeypatch, tmp_path):
     writer.run_auto()
 
     assert cfg.context_length == 40
-    assert cfg.max_tokens == 20
+    assert cfg.max_tokens == 40
     assert any(str(writer.word_count) in p[0] for p in prompts_seen)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,4 +19,4 @@ def test_adjust_for_word_count():
     cfg = Config()
     cfg.adjust_for_word_count(50)
     assert cfg.context_length == 200
-    assert cfg.max_tokens == 100
+    assert cfg.max_tokens == 200

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -25,7 +25,7 @@ class Config:
     context_length: int = 2048
     max_tokens: int = 256
     auto_ctx_multiplier: int = 4
-    auto_token_multiplier: int = 2
+    auto_token_multiplier: int = 4
     openai_api_key: str | None = None
     openai_url: str = "https://api.openai.com/v1/chat/completions"
     ollama_url: str = "http://192.168.100.148:11434/api/generate"


### PR DESCRIPTION
## Summary
- double token multiplier for automatic mode to expand generation length
- update tests for new token limit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abf37582f483258bf6d0f52f2c2791