### PR TITLE
Double context limit in automatic mode

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -455,7 +455,7 @@ def test_run_auto_sets_token_limits(monkeypatch, tmp_path):
     monkeypatch.setattr(writer, '_call_llm', fake_call_llm)
     writer.run_auto()
 
-    assert cfg.context_length == 40
+    assert cfg.context_length == 80
     assert cfg.max_tokens == 40
     assert any(str(writer.word_count) in p[0] for p in prompts_seen)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,5 +18,5 @@ def test_config_creates_directories(tmp_path):
 def test_adjust_for_word_count():
     cfg = Config()
     cfg.adjust_for_word_count(50)
-    assert cfg.context_length == 200
+    assert cfg.context_length == 400
     assert cfg.max_tokens == 200

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -24,7 +24,7 @@ class Config:
     temperature: float = 0.7
     context_length: int = 2048
     max_tokens: int = 256
-    auto_ctx_multiplier: int = 4
+    auto_ctx_multiplier: int = 8
     auto_token_multiplier: int = 4
     openai_api_key: str | None = None
     openai_url: str = "https://api.openai.com/v1/chat/completions"


### PR DESCRIPTION
## Summary
- double automatic mode context window by raising `auto_ctx_multiplier` from 4 to 8
- update tests for new automatic context scaling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abf6bf929483258b0f2b83758ffdd3