### PR TITLE
Fix automatic outline section handling

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -385,6 +385,46 @@ def test_run_auto_generates_outline_and_sections(monkeypatch, tmp_path):
     assert saved[-1] == 'edited text'
 
 
+def test_run_auto_scales_outline_sections(monkeypatch, tmp_path):
+    cfg = Config(
+        log_dir=tmp_path / 'logs',
+        output_dir=tmp_path / 'out',
+        output_file='story.txt',
+    )
+
+    writer = agent.WriterAgent(
+        'Title',
+        10,
+        [],
+        iterations=0,
+        config=cfg,
+        content='about cats',
+        text_type='Essay',
+    )
+
+    responses = iter(
+        [
+            'idea',
+            '1. Intro (100)\n2. End (100)',
+            '1. Intro (100)\n2. End (100) improved',
+            'intro ' * 20,
+            'end ' * 20,
+            'check',
+            'fixed',
+        ]
+    )
+
+    monkeypatch.setattr(writer, '_call_llm', lambda *args, **kwargs: next(responses))
+    saved: list[str] = []
+    monkeypatch.setattr(writer, '_save_text', lambda text: saved.append(text))
+
+    writer.run_auto()
+
+    expected = ('intro ' * 5).strip() + '\n\n' + ('end ' * 5).strip()
+    assert saved[0] == ('intro ' * 5).strip()
+    assert saved[1] == expected
+
+
 def test_run_auto_saves_outline(monkeypatch, tmp_path):
     cfg = Config(
         log_dir=tmp_path / 'logs',

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -78,6 +78,7 @@ OUTLINE_IMPROVEMENT_PROMPT = (
 SECTION_SYSTEM_PROMPT = (
     "Du schreibst spannende Prosatexte auf Deutsch und hältst dich strikt an die Outline. "
     "Du bleibst konsequent in Erzählperspektive und Tempus (falls bisher nicht etabliert, wähle eines und bleibe dabei). "
+    "Bleibe konsistent im Stil. "
     "Kein Meta-Talk, keine Überschriften, keine Lehrbuch-Erklärungen. "
     "Schreibe idiomatisches Deutsch ohne Code-Switching oder Fremdsprachenfragmente (z. B. 'Geldautomat' statt 'ATM'). "
     "Dialoge werden literarisch gesetzt („…“) – keine Sprecherlabels im Drehbuchstil. "
@@ -97,7 +98,7 @@ SECTION_SYSTEM_PROMPT = (
 SECTION_PROMPT = (
     "Outline:\n{outline}\n\n"
     "Textart: {text_type}\n"
-    "Beachte die Konventionen der Textart {text_type} (keine Drehbuch-Labels, außer die Outline verlangt es). "
+    "Beachte die Anforderungen und Konventionen der Textart {text_type} (keine Drehbuch-Labels, außer die Outline verlangt es). "
     "Titel des Abschnitts: {title}\n"
     "Der Abschnitt muss mindestens {word_count} Wörtern (±10%) umfassen.\n"
     "Schreibe den Abschnitt '{title}'. "


### PR DESCRIPTION
## Summary
- Redistribute outline word counts and generate each section separately
- Preserve full text in iteration files while truncating final output to the requested length
- Ensure prompts mention style consistency and text type conventions
- Add regression test for word count scaling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acb0e30b3c8325a8c4f00f3c63a16e