### PR TITLE
feat: overhaul automatic mode

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,13 +17,9 @@ def test_cli_main(monkeypatch, tmp_path, capsys):
     captured_cfg = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(
-        topic, word_count, steps, iterations, config, content="", text_type="Text"
-    ):
+    def capturing_writer(topic, word_count, steps, iterations, config, **kwargs):
         captured_cfg['config'] = config
-        return original_writer(
-            topic, word_count, steps, iterations, config, content=content, text_type=text_type
-        )
+        return original_writer(topic, word_count, steps, iterations, config, **kwargs)
 
     monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
 
@@ -104,13 +100,9 @@ def test_cli_ollama_model_selection(monkeypatch, tmp_path, capsys):
     captured_cfg = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(
-        topic, word_count, steps, iterations, config, content="", text_type="Text"
-    ):
+    def capturing_writer(topic, word_count, steps, iterations, config, **kwargs):
         captured_cfg['config'] = config
-        return original_writer(
-            topic, word_count, steps, iterations, config, content=content, text_type=text_type
-        )
+        return original_writer(topic, word_count, steps, iterations, config, **kwargs)
 
     monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
 
@@ -182,19 +174,15 @@ def test_cli_defaults(monkeypatch, tmp_path, capsys):
     captured_args = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(
-        topic, word_count, steps, iterations, config, content="", text_type="Text"
-    ):
+    def capturing_writer(topic, word_count, steps, iterations, config, **kwargs):
         captured_args['topic'] = topic
         captured_args['word_count'] = word_count
         captured_args['steps'] = steps
         captured_args['iterations'] = iterations
         captured_args['config'] = config
-        captured_args['content'] = content
-        captured_args['text_type'] = text_type
-        return original_writer(
-            topic, word_count, steps, iterations, config, content=content, text_type=text_type
-        )
+        captured_args['content'] = kwargs.get('content')
+        captured_args['text_type'] = kwargs.get('text_type', 'Text')
+        return original_writer(topic, word_count, steps, iterations, config, **kwargs)
 
     monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
 
@@ -228,22 +216,35 @@ def test_cli_auto_mode(monkeypatch, tmp_path, capsys):
     captured = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(
-        topic, word_count, steps, iterations, config, content="", text_type="Text"
-    ):
+    def capturing_writer(topic, word_count, steps, iterations, config, **kwargs):
         captured['topic'] = topic
-        captured['content'] = content
+        captured['content'] = kwargs.get('content')
         captured['iterations'] = iterations
         captured['steps'] = steps
         captured['config'] = config
-        captured['text_type'] = text_type
-        return original_writer(
-            topic, word_count, steps, iterations, config, content=content, text_type=text_type
-        )
+        captured['text_type'] = kwargs.get('text_type')
+        captured['audience'] = kwargs.get('audience')
+        return original_writer(topic, word_count, steps, iterations, config, **kwargs)
 
     monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
 
-    inputs = iter(['y', 'My Title', 'A cat story', 'Essay', '5', '2', 'stub', 'test-model'])
+    inputs = iter([
+        'y',
+        'My Title',
+        'A cat story',
+        'Essay',
+        'Adults',
+        'formal',
+        'Sie',
+        'DE-DE',
+        '',
+        'y',
+        '',
+        '5',
+        '2',
+        'stub',
+        'test-model',
+    ])
     monkeypatch.setattr('builtins.input', lambda _: next(inputs))
 
     cli.main()
@@ -254,6 +255,7 @@ def test_cli_auto_mode(monkeypatch, tmp_path, capsys):
     assert captured['content'] == 'A cat story'
     assert captured['iterations'] == 2
     assert captured['text_type'] == 'Essay'
+    assert captured['audience'] == 'Adults'
     cfg_used = captured['config']
     assert cfg_used.llm_provider == 'stub'
     assert cfg_used.model == 'test-model'
@@ -271,17 +273,30 @@ def test_cli_auto_mode_ollama_custom_ip(monkeypatch, tmp_path, capsys):
     captured = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(
-        topic, word_count, steps, iterations, config, content="", text_type="Text"
-    ):
+    def capturing_writer(topic, word_count, steps, iterations, config, **kwargs):
         captured['config'] = config
-        return original_writer(
-            topic, word_count, steps, iterations, config, content=content, text_type=text_type
-        )
+        return original_writer(topic, word_count, steps, iterations, config, **kwargs)
 
     monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
 
-    inputs = iter(['y', 'T', 'C', 'Essay', '5', '1', '', '10.1.1.1', ''])
+    inputs = iter([
+        'y',
+        'T',
+        'C',
+        'Essay',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '5',
+        '1',
+        '',
+        '10.1.1.1',
+        '',
+    ])
     monkeypatch.setattr('builtins.input', lambda _: next(inputs))
 
     cli.main()
@@ -305,18 +320,31 @@ def test_cli_auto_mode_openai_endpoint(monkeypatch, tmp_path, capsys):
     captured = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(
-        topic, word_count, steps, iterations, config, content="", text_type="Text"
-    ):
+    def capturing_writer(topic, word_count, steps, iterations, config, **kwargs):
         captured['config'] = config
-        return original_writer(
-            topic, word_count, steps, iterations, config, content=content, text_type=text_type
-        )
+        return original_writer(topic, word_count, steps, iterations, config, **kwargs)
 
     monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
 
     inputs = iter(
-        ['y', 'T', 'C', 'Report', '5', '1', 'openai', 'gpt', 'http://custom']
+        [
+            'y',
+            'T',
+            'C',
+            'Report',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '5',
+            '1',
+            'openai',
+            'gpt',
+            'http://custom',
+        ]
     )
     monkeypatch.setattr('builtins.input', lambda _: next(inputs))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,10 @@ def test_config_creates_directories(tmp_path):
     cfg.ensure_dirs()
     assert cfg.log_dir.exists()
     assert cfg.output_dir.exists()
-    assert cfg.temperature == 0.7
+    assert cfg.temperature == 0.2
+    assert cfg.top_p == 0.9
+    assert cfg.presence_penalty == 0.0
+    assert cfg.frequency_penalty == 0.3
     assert cfg.context_length == 2048
     assert cfg.max_tokens == 256
     assert cfg.log_encoding == 'utf-8'

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -23,7 +23,7 @@ def test_system_prompts_quality_phrases():
     assert "Rechtschreib- und Grammatikfehler" in prompts.IDEA_IMPROVEMENT_SYSTEM_PROMPT
     assert "klare Hierarchien" in prompts.OUTLINE_SYSTEM_PROMPT
     assert "Charakterisierung der Figuren" in prompts.OUTLINE_IMPROVEMENT_SYSTEM_PROMPT
-    assert "konsistent im Stil" in prompts.SECTION_SYSTEM_PROMPT
+    assert "konsequent im Stil" in prompts.SECTION_SYSTEM_PROMPT
     assert "Stil, Kohärenz und Grammatik" in prompts.REVISION_SYSTEM_PROMPT
     assert "vermeidest Mehrdeutigkeiten" in prompts.PROMPT_CRAFTING_SYSTEM_PROMPT
     assert "Figuren, Ton und Spannung" in prompts.STEP_SYSTEM_PROMPT
@@ -31,29 +31,29 @@ def test_system_prompts_quality_phrases():
     assert "Textchecks" in prompts.TEXT_TYPE_FIX_SYSTEM_PROMPT
 
 
-def test_section_prompt_mentions_text_type():
-    assert "Textart: {text_type}" in prompts.SECTION_PROMPT
-    assert "Anforderungen und Konventionen der Textart" in prompts.SECTION_PROMPT
-
-
-def test_outline_prompt_mentions_character_lines():
+def test_outline_prompt_mentions_briefing():
     text = prompts.OUTLINE_PROMPT.format(
-        text_type='Roman',
+        text_type='Report',
         title='Titel',
-        content='Inhalt',
+        briefing_json='{}',
         word_count=100,
     )
-    assert 'Jede Zeile beginnt mit #' in text
+    assert 'Briefing' in text
+    assert 'Rollenfunktion' in text
 
 
-def test_outline_prompt_enforces_subpoint_asterisks():
-    text = prompts.OUTLINE_PROMPT.format(
-        text_type='Roman',
-        title='Titel',
-        content='Inhalt',
-        word_count=100,
+def test_section_prompt_mentions_briefing():
+    text = prompts.SECTION_PROMPT.format(
+        section_number=1,
+        section_title='Einleitung',
+        role='Hook',
+        deliverable='Ziel',
+        budget=100,
+        briefing_json='{}',
+        previous_section_recap='',
     )
-    assert 'Unterpunkte müssen mit * beginnen' in text
+    assert 'Briefing' in text
+    assert 'Zielwortzahl' in text
 
 
 def test_text_type_fix_prompt_mentions_issues():
@@ -61,5 +61,5 @@ def test_text_type_fix_prompt_mentions_issues():
         issues='Fehler',
         current_text='Inhalt',
     )
-    assert 'Textcheck hat ergeben' in text
+    assert 'Rubrik-Check hat ergeben' in text
     assert 'Behebe sie' in text

--- a/wordsmith/cli.py
+++ b/wordsmith/cli.py
@@ -47,6 +47,20 @@ def _run_cli() -> None:
         topic = input(f"Title [{default_topic}]: ").strip() or default_topic
         content = input("Desired content: ").strip()
         text_type = input("Text type: ").strip() or "Text"
+        audience = (
+            input(
+                "Audience [Allgemeine Leserschaft mit Grundkenntnissen]: "
+            ).strip()
+            or "Allgemeine Leserschaft mit Grundkenntnissen"
+        )
+        tone = input("Tone [sachlich-lebendig]: ").strip() or "sachlich-lebendig"
+        register = input("Register [Sie]: ").strip() or "Sie"
+        variant = input("Variant [DE-DE]: ").strip() or "DE-DE"
+        constraints = input("Constraints (optional): ").strip()
+        sources_allowed = (
+            input("Sources allowed? (y/N): ").strip().lower() == "y"
+        )
+        seo_keywords = input("SEO keywords (optional): ").strip()
         word_count = _prompt_int("Word count [100]: ", default=100)
         iterations = _prompt_int("Number of iterations [1]: ", default=1)
 
@@ -110,6 +124,13 @@ def _run_cli() -> None:
             config=cfg,
             content=content,
             text_type=text_type,
+            audience=audience,
+            tone=tone,
+            register=register,
+            variant=variant,
+            constraints=constraints,
+            sources_allowed=sources_allowed,
+            seo_keywords=seo_keywords,
         )
         final_text = writer.run_auto()
 

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -21,7 +21,11 @@ class Config:
     log_encoding: str = "utf-8"
     llm_provider: str = "stub"
     model: str = "gpt-3.5-turbo"
-    temperature: float = 0.7
+    temperature: float = 0.2
+    top_p: float = 0.9
+    presence_penalty: float = 0.0
+    frequency_penalty: float = 0.3
+    seed: int | None = None
     context_length: int = 2048
     max_tokens: int = 256
     auto_ctx_multiplier: int = 8

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -1,17 +1,20 @@
 """Prompt templates used by WriterAgent."""
 
+# Global system prompt used for all LLM calls in automatic mode
 SYSTEM_PROMPT = (
-    "Du bist eine erfahrene, kreative Autorin und Lektorin. "
-    "Du verfasst gut strukturierte und ansprechende {text_type} in klarem Deutsch. "
-    "Nutze eine präzise, lebendige Sprache, achte auf logische Übergänge und einen natürlichen Stil. "
+    "Du bist ein präziser deutschsprachiger Fachtexter. "
+    "Du erfindest keine Fakten. Bei fehlenden Daten nutzt du Platzhalter in eckigen Klammern. "
+    "Deine Texte sind klar strukturiert, aktiv formuliert, redundanzarm und adressatengerecht. "
     "Vermeide Wiederholungen und Füllwörter und achte besonders auf die inhaltliche Qualität des Textes. "
-    "Dein Thema lautet: {topic}."
+    "Dein Thema lautet: {topic}. Du verfasst einen {text_type}."
 )
 
+# Prompts for interactive/legacy features remain largely unchanged
 META_SYSTEM_PROMPT = (
     "Du bist ein kreativer, strukturierter Schreibcoach, der Autorinnen hilft, den nächsten "
     "sinnvollen Schritt zu planen und ihre Texte zu verfeinern."
 )
+
 META_PROMPT = (
     "Du arbeitest an einem {text_type} mit dem Titel: {title}\n"
     "Er behandelt folgenden Inhalt: {content}\n"
@@ -26,141 +29,125 @@ META_PROMPT = (
     "so dass daraus eine kreative und literarisch hochwertige Erweiterung der Geschichte entstehen kann."
 )
 
-
 INITIAL_AUTO_SYSTEM_PROMPT = (
     "Du bist eine erfahrene Autorin, die aus kurzen Vorgaben einen hochwertigen ersten Rohtext entwickelt."
 )
-INITIAL_AUTO_PROMPT = (
-    "Schreibe diesen Text als erfahrene Autorin mit Jahrzehnten an Erfahrung.\n"
-    "Titel: {title}\n"
-    "Textart: {text_type}\n"
-    "Inhalt: {content}\n"
-    "Er soll etwa {word_count} Wörter umfassen."
-    "Achte auf einen klaren, ansprechenden Stil und logische Übergänge. "
-    "Beachte die Konventionen der Textart {text_type}.\n"
+
+# ---------------------------------------------------------------------------
+# Prompts for the revised automatic mode
+
+BRIEFING_PROMPT = (
+    "Verdichte folgende Angaben zu einem Arbeitsbriefing als kompaktes JSON mit Schlüsseln: "
+    "goal, audience, tone, register, variant, constraints, key_terms, messages, seo_keywords (optional), no_gos.\n"
+    "**Eingaben:**\n"
+    "title: {title}\n"
+    "text_type: {text_type}\n"
+    "audience: {audience}\n"
+    "tone: {tone}\n"
+    "register: {register}\n"
+    "variant: {variant}\n"
+    "constraints: {constraints}\n"
+    "seo_keywords: {seo_keywords}\n"
+    "notes: {content}\n"
 )
 
 IDEA_IMPROVEMENT_SYSTEM_PROMPT = (
-    "Du überarbeitest Ideen, korrigierst Rechtschreib- und Grammatikfehler und formulierst sie klarer. "
-    "Wenn sinnvoll, ergänzt du ein oder zwei originelle Aspekte."
+    "Du überarbeitest Ideen, korrigierst Rechtschreib- und Grammatikfehler und formulierst sie klarer."
 )
+
 IDEA_IMPROVEMENT_PROMPT = (
-    "Überarbeite die folgende Idee.\n"
-    "Korrigiere Rechtschreib- und Grammatikfehler, formuliere sie prägnanter und ergänze, "
-    "falls passend, ein oder zwei originelle Aspekte.\n\n"
-    "Idee:\n{content}\n"
+    "Überarbeite diesen Rohinhalt ohne neue Fakten.\n"
+    "1) Straffe Sprache, 2) markiere Unklarheiten `[KLÄREN: …]`, 3) gib Kernaussagen als Bullets + 1-Satz-Summary.\n"
+    "**Rohinhalt:** {content}"
 )
 
 OUTLINE_SYSTEM_PROMPT = (
     "Du gliederst Themen in übersichtliche, gut strukturierte Outlines und achtest auf klare Hierarchien "
     "sowie eine sinnvolle Reihenfolge."
 )
+
 OUTLINE_PROMPT = (
-    "Erstelle eine gegliederte Outline für einen {text_type} mit dem Titel: {title}\n"
-    "Der Text behandelt folgenden Inhalt: {content}\n"
-    "Die Gesamtlänge beträgt etwa {word_count} Wörter.\n"
-    "Alle Unterpunkte müssen mit * beginnen.\n"
-    "Gib eine nummerierte Liste der Abschnitte zurück und vermerke in Klammern den ungefähren Wortumfang jedes Abschnitts.\n"
-    "Füge am Ende eine Liste aller Figuren hinzu, die vorkommen sollen. "
-    "Jede Zeile beginnt mit # und enthält eine kurze Charakterisierung."
+    "Erzeuge eine hierarchische Gliederung für `{text_type}` zu `{title}` basierend auf dem Briefing:\n"
+    "{briefing_json}\n"
+    "Für jeden Abschnitt: Nummer, Titel, Rollenfunktion, Wortbudget, Liefergegenstand.\n"
+    "Gesamtwortzahl: {word_count}. Keine Fakten erfinden."
 )
 
 OUTLINE_IMPROVEMENT_SYSTEM_PROMPT = (
     "Du überarbeitest Outlines, vertiefst die Charakterisierung der Figuren und sorgst für eine klare, konsistente Struktur."
 )
+
 OUTLINE_IMPROVEMENT_PROMPT = (
-    "Überarbeite die folgende Outline.\n"
-    "Schärfe besonders die Charakterisierungen der Figuren und ergänze, wo sinnvoll, weitere Details.\n"
-    "Erhalte die nummerierte Gliederung sowie die abschließende Figurenliste.\n\n"
-    "Outline:\n{outline}\n"
+    "Prüfe und verbessere die Outline: entferne Überschneidungen, füge fehlende Brücken, balanciere Budgets (Summe = {word_count}). "
+    "Behalte Faktenneutralität.\n\nOutline:\n{outline}\n"
 )
 
 SECTION_SYSTEM_PROMPT = (
-    "Du schreibst spannende Prosatexte auf Deutsch und hältst dich strikt an die Outline. "
-    "Du bleibst konsequent in Erzählperspektive und Tempus (falls bisher nicht etabliert, wähle eines und bleibe dabei). "
-    "Bleibe konsistent im Stil. "
-    "Kein Meta-Talk, keine Überschriften, keine Lehrbuch-Erklärungen. "
-    "Schreibe idiomatisches Deutsch ohne Code-Switching oder Fremdsprachenfragmente (z. B. 'Geldautomat' statt 'ATM'). "
-    "Dialoge werden literarisch gesetzt („…“) – keine Sprecherlabels im Drehbuchstil. "
-    "Zeigen statt erklären: Szenen, Sinneseindrücke, Handlungen; Vermeide Info-Dumps. "
-    "Technik bleibt plausibel (keine unmöglichen physischen Handlungen durch Software; Hardware/Netzwerk realistisch). "
-    "Behandle psychische Themen vorsichtig und präzise, ohne Diagnosen zu behaupten. "
-    "Spezialformate (Logs/Tickets/Code) nur falls in der Outline explizit vorgesehen; maximal ein Block pro Abschnitt, "
-    "kurz (1–4 Zeilen) und einheitlich formatiert. "
-    "Führe vor Ausgabe eine stille Selbstprüfung durch und korrigiere ggf.: "
-    "1) Perspektive/Tempus konsistent? 2) Keine widersprüchlichen Fakten/Ereignisse? "
-    "3) Keine Wiederholungen/Redundanzen? 4) Orthografie/Grammatik fehlerfrei? "
-    "5) Keine Fremdsprach-Schnipsel ('había', 'haby', 'later' etc.)? 6) Technik plausibel? "
-    "7) Dialogformat korrekt? 8) Keine Klischee-Floskeln ohne Twist? "
-    "9) Outline strikt befolgt? 10) Kein Meta/keine Überschriften."
+    "Du schreibst spannende Prosatexte auf Deutsch und hältst dich strikt an die Outline. Du bleibst konsequent im Stil."
 )
 
 SECTION_PROMPT = (
-    "Outline:\n{outline}\n\n"
-    "Textart: {text_type}\n"
-    "Beachte die Anforderungen und Konventionen der Textart {text_type} (keine Drehbuch-Labels, außer die Outline verlangt es). "
-    "Titel des Abschnitts: {title}\n"
-    "Der Abschnitt muss mindestens {word_count} Wörtern (±10%) umfassen.\n"
-    "Schreibe den Abschnitt '{title}'. "
-    "Verankere jede Szene klar (Ort/Zeit/Handlungsziel), führe neue Elemente nur bei erzählerischer Notwendigkeit ein "
-    "und sorge für sichtbare Ursache-Wirkung. "
-    "Wenn Logs/Tickets/Code laut Outline nötig sind, nutze ein knappes, plausibles Format, z. B.: "
-    "[16:47] ui: route injected '/settings/experiments' ; "
-    "[17:03] authd: lockout user=admin. "
-    "Sonst keine Code- oder Logblöcke."
+    "Schreibe Abschnitt {section_number} „{section_title}“ (Rolle: {role}) mit Ziel `{deliverable}`.\n"
+    "Nutze Briefing und bisherige Abschnitte (Kohärenz, Terminologie).\n"
+    "Briefing: {briefing_json}\n"
+    "Bisheriger Kontext (Kurz-Recap): {previous_section_recap}\n"
+    "Regeln: aktive Verben, keine Füllphrasen, natürliche Übergänge, keine erfundenen Fakten (Platzhalter bei Lücken).\n"
+    "Zielwortzahl: {budget}."
 )
-
 
 REVISION_SYSTEM_PROMPT = (
-    "Du überarbeitest Texte präzise, verbesserst Stil, Kohärenz und Grammatik und orientierst dich an einer "
-    "vorgegebenen Outline."
-)
-REVISION_PROMPT = (
-    "Überarbeite den folgenden {text_type} basierend auf der Outline."
-    "Die Gesamtlänge soll mindestens {word_count} Wörter betragen.\n\n"
-    "Outline:\n{outline}\n\n"
-    "Aktueller Text:\n{current_text}\n\n"
-    "Überarbeiteter Text:"
+    "Du überarbeitest Texte präzise, verbesserst Stil, Kohärenz und Grammatik und orientierst dich an einer vorgegebenen Outline."
 )
 
+REVISION_PROMPT = (
+    "Überarbeite zielgerichtet nach diesen Prioritäten: Klarheit & Prägnanz, Flow & Übergänge, Terminologie-Konsistenz, "
+    "Wiederholungen tilgen, Rhythmus variieren, spezifische Verben/Nomen stärken, Schlussteil schärfen (CTA/Resolution), "
+    "Registersicherheit ({register}), Variantenspezifika ({variant}).\n\n"
+    "Aktueller Text:\n{current_text}\n\nÜberarbeiteter Text:"
+)
+
+# ---------------------------------------------------------------------------
+# Remaining prompts used by the interactive mode and helper utilities
 
 PROMPT_CRAFTING_SYSTEM_PROMPT = (
     "Du formulierst knappe, klare Prompts für andere Sprachmodelle und vermeidest Mehrdeutigkeiten."
 )
+
 PROMPT_CRAFTING_PROMPT = (
     "Formuliere einen klaren und konkreten Prompt für ein LLM, "
     "um die Aufgabe '{task}' zum Thema '{topic}' umzusetzen. "
     "Gib nur den Prompt zurück."
 )
 
-
 STEP_SYSTEM_PROMPT = (
-    "Du führst als erfahrene Autorin eine begonnene Erzählung stilgetreu fort und greifst Figuren, Ton und Spannung des bisherigen "
-    "Textes auf."
+    "Du führst als erfahrene Autorin eine begonnene Erzählung stilgetreu fort und greifst Figuren, Ton und Spannung des bisherigen Textes auf."
 )
+
 STEP_PROMPT = (
     "{prompt}\n\nAktueller Text:\n{current_text}\n\nNächster Abschnitt:"
 )
 
-
 TEXT_TYPE_CHECK_SYSTEM_PROMPT = (
     "Du prüfst als seit 20 Jahren erfahrene Lektorin Texte darauf, ob sie den Merkmalen der angegebenen Textart entsprechen."
 )
+
 TEXT_TYPE_CHECK_PROMPT = (
-    "Prüfe, ob der folgende Text die Anforderungen der Textart {text_type} erfüllt. "
-    "Antworte knapp mit Ja oder Nein und einer kurzen Begründung.\n\n"
+    "Prüfe den folgenden Text gegen die Rubrik für `{text_type}`. Liste konkrete Abweichungen und betroffene Stellen.\n\n"
     "Text:\n{current_text}\n"
 )
 
 TEXT_TYPE_FIX_SYSTEM_PROMPT = (
     "Du überarbeitest Texte anhand eines Textchecks und behebst die genannten Mängel präzise."
 )
+
 TEXT_TYPE_FIX_PROMPT = (
-    "Der Textcheck hat ergeben, dass es folgende Mängel im Text gibt:\n"
+    "Der Rubrik-Check hat ergeben, dass es folgende Abweichungen im Text gibt:\n"
     "{issues}\n"
     "Behebe sie im folgenden Text und liefere die verbesserte Version:\n"
     "{current_text}\n"
 )
 
-
+REFLECTION_PROMPT = (
+    "Nenne die 3 wirksamsten nächsten Verbesserungen (knapp, umsetzbar)."
+)
 


### PR DESCRIPTION
## Summary
- add deterministic LLM settings and new briefing/metadata steps
- expand CLI and WriterAgent to handle audience, tone and other parameters
- revise prompt templates for structured automatic mode workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afded6a6288325940519b598f96e43