### PR TITLE
Remove no_gos from automatic mode

### DIFF
--- a/AUTOMATIC_MODE.md
+++ b/AUTOMATIC_MODE.md
@@ -46,7 +46,7 @@ Ein Durchlauf gilt als erfolgreich, wenn der finale Text:
 
 - **PROMPT `BRIEFING_PROMPT`**  
   _Eingaben:_ `title, content, text_type, audience, tone, register, variant, constraints, seo_keywords`  
-  _Ausgabe:_ kompaktes JSON (Ziel, Kernaussagen, No-Gos, definierte Begriffe, Stilvorgaben, SEO-Begriffe).  
+  _Ausgabe:_ kompaktes JSON (Ziel, Kernaussagen, definierte Begriffe, Stilvorgaben, SEO-Begriffe).
 - Dieses JSON wird in `output/briefing.json` gespeichert und in allen Folge-Prompts eingebettet.
 
 ---
@@ -178,7 +178,7 @@ Nach der letzten Iteration: finaler Text zurückgeben (Länge ±3 %).
 ## Prompt-Vorlagen (Platzhalter in `{…}`)
 
 ### `BRIEFING_PROMPT`
-> Verdichte folgende Angaben zu einem Arbeitsbriefing als kompaktes JSON mit Schlüsseln: goal, audience, tone, register, variant, constraints, key_terms, messages, seo_keywords (optional), no_gos.  
+> Verdichte folgende Angaben zu einem Arbeitsbriefing als kompaktes JSON mit Schlüsseln: goal, audience, tone, register, variant, constraints, key_terms, messages, seo_keywords (optional).
 > **Eingaben:**  
 > title: {title}  
 > text_type: {text_type}  

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -220,3 +220,18 @@ def test_run_auto_creates_briefing_and_metadata(monkeypatch, tmp_path):
     meta = json.loads(meta_path.read_text())
     assert meta['title'] == 'Title'
     assert meta['final_word_count'] == len(final_text.split())
+
+
+def test_run_auto_briefing_has_no_no_gos(monkeypatch, tmp_path):
+    cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'out')
+    writer = agent.WriterAgent('Topic', 10, [], iterations=1, config=cfg)
+
+    def fake_call(self, prompt, *, fallback, system_prompt=None):
+        return fallback
+
+    monkeypatch.setattr(agent.WriterAgent, '_call_llm', fake_call)
+
+    writer.run_auto()
+
+    briefing = json.loads((cfg.output_dir / 'briefing.json').read_text())
+    assert 'no_gos' not in briefing

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -63,3 +63,7 @@ def test_text_type_fix_prompt_mentions_issues():
     )
     assert 'Rubrik-Check hat ergeben' in text
     assert 'Behebe sie' in text
+
+
+def test_briefing_prompt_has_no_no_gos():
+    assert 'no_gos' not in prompts.BRIEFING_PROMPT

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -167,7 +167,6 @@ class WriterAgent:
                 "key_terms": [],
                 "messages": [],
                 "seo_keywords": [k.strip() for k in self.seo_keywords.split(",") if k.strip()],
-                "no_gos": [],
             }
         )
         briefing_json = self._call_llm(briefing_prompt, fallback=fallback_briefing)

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -38,7 +38,7 @@ INITIAL_AUTO_SYSTEM_PROMPT = (
 
 BRIEFING_PROMPT = (
     "Verdichte folgende Angaben zu einem Arbeitsbriefing als kompaktes JSON mit Schlüsseln: "
-    "goal, audience, tone, register, variant, constraints, key_terms, messages, seo_keywords (optional), no_gos.\n"
+    "goal, audience, tone, register, variant, constraints, key_terms, messages, seo_keywords (optional).\n"
     "**Eingaben:**\n"
     "title: {title}\n"
     "text_type: {text_type}\n"


### PR DESCRIPTION
## Summary
- drop `no_gos` from the automatic mode briefing prompt and agent fallback
- update Automatikmodus guide to no longer reference no-gos
- add tests ensuring prompts and fallback briefing omit `no_gos`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aff5ee3ae483258c092131e8a4f578