### PR TITLE
Ensure outline generation meets word count requirement

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -187,6 +187,25 @@ def test_generate_sections_from_outline_extends_short_sections(monkeypatch, tmp_
     assert len(prompts_seen) == 2
 
 
+def test_generate_sections_from_outline_extends_final_section(monkeypatch, tmp_path):
+    cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'out')
+    writer = agent.WriterAgent('Topic', 5, [], iterations=0, config=cfg)
+    outline = '1. Intro | Rolle: Hook | Wortbudget: 5 | Liefergegenstand: Start'
+
+    prompts_seen = []
+    responses = iter(['kurz', '', 'jetzt kommen genug worte'])
+
+    def fake_call(self, prompt, *, fallback, system_prompt=None):
+        prompts_seen.append(prompt)
+        return next(responses)
+
+    monkeypatch.setattr(agent.WriterAgent, '_call_llm', fake_call)
+
+    limited, full = writer._generate_sections_from_outline(outline, '{}')
+    assert len(full.split()) >= 5
+    assert len(prompts_seen) == 3
+
+
 def test_run_auto_creates_briefing_and_metadata(monkeypatch, tmp_path):
     cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'out')
     writer = agent.WriterAgent(


### PR DESCRIPTION
## Summary
- Extend section generation to keep writing until the overall text meets the required word count
- Add regression test for extending the final section when initial attempts fall short

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68affd9020ec8325acb86d0fba0c8338