### PR TITLE
Clarify steps in LLM logging

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -32,5 +32,8 @@ def test_logging_records_iteration(tmp_path):
     run_log = (cfg.log_dir / cfg.log_file).read_text("utf-8")
     assert "iteration 1/1" in run_log
     llm_lines = (cfg.log_dir / cfg.llm_log_file).read_text("utf-8").splitlines()
-    iterations = {json.loads(line)["iteration"] for line in llm_lines}
+    parsed = [json.loads(line) for line in llm_lines]
+    iterations = {entry["iteration"] for entry in parsed}
+    steps = {entry.get("step") for entry in parsed}
     assert 1 in iterations
+    assert 1 in steps

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -65,6 +65,8 @@ class WriterAgent:
         self.sources_allowed = sources_allowed
         self.seo_keywords = seo_keywords
         self.iteration = 0
+        self.step_index = 0
+        self.step_task = ""
 
         self.config.ensure_dirs()
 
@@ -103,6 +105,8 @@ class WriterAgent:
 
         text: List[str] = []
         for step_index, step in enumerate(self.steps, start=1):
+            self.step_index = step_index
+            self.step_task = step.task
             # Ask the LLM for an optimal prompt for this step before running any
             # iterations.
             prompt = self._craft_prompt(step.task)
@@ -536,12 +540,16 @@ class WriterAgent:
 
         full_prompt = f"{combined_system}\n\n{prompt}".strip()
         iteration = self.iteration
+        step = getattr(self, "step_index", 0)
+        task = getattr(self, "step_task", "")
         # Log structured JSON to allow easier parsing and to keep entries on a single line
         self.llm_logger.info(
             json.dumps(
                 {
                     "time": datetime.now(timezone.utc).isoformat(),
                     "event": "prompt",
+                    "step": step,
+                    "task": task,
                     "iteration": iteration,
                     "text": full_prompt,
                 },
@@ -620,6 +628,8 @@ class WriterAgent:
                 {
                     "time": datetime.now(timezone.utc).isoformat(),
                     "event": "response",
+                    "step": step,
+                    "task": task,
                     "iteration": iteration,
                     "text": result,
                 },


### PR DESCRIPTION
## Summary
- Track current step index and task when generating text
- Include step and task metadata in structured LLM log entries
- Test ensures step numbers are recorded in LLM logs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b021ee3f488325b9fdccd8030972a9