### PR TITLE
Fix repeated text generation

### DIFF
--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -520,7 +520,7 @@ class WriterAgent:
             return ""
 
         existing = " ".join(previous_sections).strip()
-        if existing and cleaned.startswith(existing):
+        while existing and cleaned.startswith(existing):
             cleaned = cleaned[len(existing) :].lstrip()
 
         if any(cleaned == part.strip() for part in previous_sections):


### PR DESCRIPTION
## Summary
- remove repeated prefix sections from LLM output
- test duplicate removal for multiple repeated prefixes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b02a7dbb5c83258746ca5762fee09d