### PR TITLE
Remove interactive mode and rely on automatic workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # WordSmith
 
-WordSmith is a tiny demonstration project for an iterative writing agent.
-The command‑line interface guides a user through a sequence of steps and
-records intermediate results.
+WordSmith is a tiny demonstration project for an automatic writing agent.
+The command‑line interface collects a brief and generates a complete text
+without manual step definitions.
 
 ## Usage
 
@@ -10,24 +10,11 @@ records intermediate results.
 python -m wordsmith.cli
 ```
 
-The program will prompt for:
+The program will prompt for details such as title, desired content, text type,
+audience, tone, register, variant, optional constraints and keywords, desired
+word count, revision count, and LLM provider (stub/Ollama/OpenAI). When using
+Ollama the available models are listed for selection. Each prompt displays a
+default in square brackets and pressing Enter accepts it.
 
-1. **Topic** – the subject of the text.
-2. **Word count** – approximate length of the final output.
-3. **Number of steps** – how many distinct phases the writing process has.
-4. **Iterations per step** – how many times each phase should run.
-5. **Task for each step** – a short description of what should happen in that
-   step.
-6. **LLM provider** – choose between the stub and real providers. When using
-   the Ollama provider, the available models are fetched automatically and you
-   can select one from a numbered list.
-7. **Model name** – which LLM model to use.
-8. **Temperature** – randomness of the model's output.
-9. **Context length** – maximum token context for the model.
-10. **Max tokens** – limit for tokens generated per request.
-
-Each prompt displays a default value in square brackets. Pressing Enter
-accepts the default.
-
-During execution a log is written to `logs/run.log` and the current state of
-the text is stored in `output/current_text.txt`.
+During execution a log is written to `logs/run.log` and the evolving text is
+stored in `output/current_text.txt`.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,371 +2,172 @@ import sys, pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import wordsmith.agent as agent
-from wordsmith import cli
+import wordsmith.cli as cli
 from wordsmith.config import Config
-
-
-def test_cli_main(monkeypatch, tmp_path, capsys):
-    cfg = Config(
-        log_dir=tmp_path / 'logs',
-        output_dir=tmp_path / 'output',
-        output_file='story.txt',
-    )
-    monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
-
-    captured_cfg = {}
-    original_writer = agent.WriterAgent
-
-    def capturing_writer(topic, word_count, steps, iterations, config, **kwargs):
-        captured_cfg['config'] = config
-        return original_writer(topic, word_count, steps, iterations, config, **kwargs)
-
-    monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
-
-    inputs = iter(
-        [
-            'n',
-            'Cats',
-            '5',
-            '1',
-            '1',
-            'intro',
-            'stub',
-            'test-model',
-            '0.5',
-            '128',
-            '256',
-        ]
-    )
-    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
-
-    cli.main()
-
-    captured = capsys.readouterr()
-    assert 'Final text:' in captured.out
-    assert 'tok/s' in captured.out
-    assert (tmp_path / 'logs' / 'run.log').exists()
-    assert (tmp_path / 'output' / 'story.txt').exists()
-    assert captured_cfg['config'].llm_provider == 'stub'
-    assert captured_cfg['config'].model == 'test-model'
-    assert captured_cfg['config'].temperature == 0.5
-    assert captured_cfg['config'].context_length == 128
-    assert captured_cfg['config'].max_tokens == 256
-
-
-def test_cli_invalid_numeric_input(monkeypatch, tmp_path, capsys):
-    cfg = Config(
-        log_dir=tmp_path / 'logs',
-        output_dir=tmp_path / 'output',
-        output_file='story.txt',
-    )
-    monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
-
-    inputs = iter(
-        [
-            'n',
-            'Cats',
-            'five', '5',
-            '1',
-            '1',
-            'intro',
-            'stub',
-            'test-model',
-            'abc', '0.5',
-            'xyz', '128',
-            'pqr', '256',
-        ]
-    )
-    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
-
-    cli.main()
-
-    captured = capsys.readouterr()
-    assert captured.out.count('Invalid input') == 4
-    assert 'Final text:' in captured.out
-    assert 'tok/s' in captured.out
-
-
-def test_cli_ollama_model_selection(monkeypatch, tmp_path, capsys):
-    cfg = Config(
-        log_dir=tmp_path / 'logs',
-        output_dir=tmp_path / 'output',
-        output_file='story.txt',
-    )
-    monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
-
-    monkeypatch.setattr(cli, '_fetch_ollama_models', lambda url: ['m1', 'm2'])
-
-    captured_cfg = {}
-    original_writer = agent.WriterAgent
-
-    def capturing_writer(topic, word_count, steps, iterations, config, **kwargs):
-        captured_cfg['config'] = config
-        return original_writer(topic, word_count, steps, iterations, config, **kwargs)
-
-    monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
-
-    inputs = iter(
-        [
-            'n',
-            'Cats',
-            '5',
-            '1',
-            '1',
-            'intro',
-            'ollama',
-            '2',
-            '0.5',
-            '128',
-            '256',
-        ]
-    )
-    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
-
-    cli.main()
-
-    captured = capsys.readouterr()
-    assert 'Final text:' in captured.out
-    assert 'tok/s' in captured.out
-    assert captured_cfg['config'].llm_provider == 'ollama'
-    assert captured_cfg['config'].model == 'm2'
-    assert captured_cfg['config'].max_tokens == 256
-
-
-def test_cli_ollama_no_models(monkeypatch, tmp_path, capsys):
-    cfg = Config(
-        log_dir=tmp_path / 'logs',
-        output_dir=tmp_path / 'output',
-        output_file='story.txt',
-    )
-    monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
-
-    # Simulate no models being returned from Ollama
-    monkeypatch.setattr(cli, '_fetch_ollama_models', lambda url: [])
-
-    inputs = iter([
-        'n',
-        'Cats',
-        '5',
-        '1',
-        '1',
-        'intro',
-        'ollama',
-    ])
-    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
-
-    cli.main()
-
-    captured = capsys.readouterr()
-    assert 'No models available from Ollama.' in captured.out
-
-
-def test_cli_defaults(monkeypatch, tmp_path, capsys):
-    cfg = Config(
-        log_dir=tmp_path / 'logs',
-        output_dir=tmp_path / 'output',
-        output_file='story.txt',
-        model='default-model',
-        max_tokens=64,
-    )
-    monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
-
-    captured_args = {}
-    original_writer = agent.WriterAgent
-
-    def capturing_writer(topic, word_count, steps, iterations, config, **kwargs):
-        captured_args['topic'] = topic
-        captured_args['word_count'] = word_count
-        captured_args['steps'] = steps
-        captured_args['iterations'] = iterations
-        captured_args['config'] = config
-        captured_args['content'] = kwargs.get('content')
-        captured_args['text_type'] = kwargs.get('text_type', 'Text')
-        return original_writer(topic, word_count, steps, iterations, config, **kwargs)
-
-    monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
-
-    inputs = iter(['n', '', '', '', '', '', '', '', '', '', ''])
-    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
-
-    cli.main()
-
-    assert captured_args['topic'] == 'Untitled'
-    assert captured_args['word_count'] == 100
-    assert len(captured_args['steps']) == 1
-    assert captured_args['steps'][0].task == 'Step 1'
-    assert captured_args['iterations'] == 1
-    cfg_used = captured_args['config']
-    assert cfg_used.llm_provider == 'stub'
-    assert cfg_used.model == 'default-model'
-    assert cfg_used.temperature == cfg.temperature
-    assert cfg_used.context_length == cfg.context_length
-    assert cfg_used.max_tokens == cfg.max_tokens
-    assert captured_args['text_type'] == 'Text'
 
 
 def test_cli_auto_mode(monkeypatch, tmp_path, capsys):
     cfg = Config(
-        log_dir=tmp_path / 'logs',
-        output_dir=tmp_path / 'output',
-        output_file='story.txt',
+        log_dir=tmp_path / "logs",
+        output_dir=tmp_path / "output",
+        output_file="story.txt",
     )
-    monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
+    monkeypatch.setattr(agent, "DEFAULT_CONFIG", cfg)
 
     captured = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(topic, word_count, steps, iterations, config, **kwargs):
-        captured['topic'] = topic
-        captured['content'] = kwargs.get('content')
-        captured['iterations'] = iterations
-        captured['steps'] = steps
-        captured['config'] = config
-        captured['text_type'] = kwargs.get('text_type')
-        captured['audience'] = kwargs.get('audience')
-        return original_writer(topic, word_count, steps, iterations, config, **kwargs)
+    def capturing_writer(topic, word_count, iterations, config, **kwargs):
+        captured["topic"] = topic
+        captured["content"] = kwargs.get("content")
+        captured["iterations"] = iterations
+        captured["config"] = config
+        captured["text_type"] = kwargs.get("text_type")
+        captured["audience"] = kwargs.get("audience")
+        return original_writer(topic, word_count, iterations, config=config, **kwargs)
 
-    monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
+    monkeypatch.setattr(agent, "WriterAgent", capturing_writer)
 
-    inputs = iter([
-        'y',
-        'My Title',
-        'A cat story',
-        'Essay',
-        'Adults',
-        'formal',
-        'Sie',
-        'DE-DE',
-        '',
-        'y',
-        '',
-        '5',
-        '2',
-        'stub',
-        'test-model',
-    ])
-    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+    inputs = iter(
+        [
+            "My Title",  # title
+            "A cat story",  # content
+            "Essay",  # text type
+            "Adults",  # audience
+            "formal",  # tone
+            "Sie",  # register
+            "DE-DE",  # variant
+            "",  # constraints
+            "y",  # sources allowed
+            "",  # seo keywords
+            "5",  # word count
+            "2",  # iterations
+            "stub",  # provider
+            "test-model",  # model name
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     cli.main()
 
     out = capsys.readouterr().out
-    assert 'Final text:' in out
-    assert 'Generating sections:' in out
+    assert "Final text:" in out
+    assert "Generating sections:" in out
     assert f"Revising: {captured['iterations']}/{captured['iterations']}" in out
-    assert captured['steps'] == []
-    assert captured['content'] == 'A cat story'
-    assert captured['iterations'] == 2
-    assert captured['text_type'] == 'Essay'
-    assert captured['audience'] == 'Adults'
-    cfg_used = captured['config']
-    assert cfg_used.llm_provider == 'stub'
-    assert cfg_used.model == 'test-model'
+    assert captured["content"] == "A cat story"
+    assert captured["iterations"] == 2
+    assert captured["text_type"] == "Essay"
+    assert captured["audience"] == "Adults"
+    cfg_used = captured["config"]
+    assert cfg_used.llm_provider == "stub"
+    assert cfg_used.model == "test-model"
 
 
 def test_cli_auto_mode_ollama_custom_ip(monkeypatch, tmp_path, capsys):
     cfg = Config(
-        log_dir=tmp_path / 'logs',
-        output_dir=tmp_path / 'output',
-        output_file='story.txt',
+        log_dir=tmp_path / "logs",
+        output_dir=tmp_path / "output",
+        output_file="story.txt",
     )
-    monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
-    monkeypatch.setattr(cli, '_fetch_ollama_models', lambda url: ['m1'])
+    monkeypatch.setattr(agent, "DEFAULT_CONFIG", cfg)
+    monkeypatch.setattr(cli, "_fetch_ollama_models", lambda url: ["m1"])
 
     captured = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(topic, word_count, steps, iterations, config, **kwargs):
-        captured['config'] = config
-        return original_writer(topic, word_count, steps, iterations, config, **kwargs)
+    def capturing_writer(topic, word_count, iterations, config, **kwargs):
+        captured["config"] = config
+        return original_writer(topic, word_count, iterations, config=config, **kwargs)
 
-    monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
+    monkeypatch.setattr(agent, "WriterAgent", capturing_writer)
 
-    inputs = iter([
-        'y',
-        'T',
-        'C',
-        'Essay',
-        '',
-        '',
-        '',
-        '',
-        '',
-        '',
-        '',
-        '5',
-        '1',
-        '',
-        '10.1.1.1',
-        '',
-    ])
-    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+    inputs = iter(
+        [
+            "T",  # title
+            "C",  # content
+            "Essay",  # text type
+            "",  # audience
+            "",  # tone
+            "",  # register
+            "",  # variant
+            "",  # constraints
+            "",  # sources allowed
+            "",  # seo keywords
+            "5",  # word count
+            "1",  # iterations
+            "",  # provider -> default ollama
+            "10.1.1.1",  # custom IP
+            "",  # model selection default 1
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     cli.main()
 
     out = capsys.readouterr().out
-    assert 'Final text:' in out
-    cfg_used = captured['config']
-    assert cfg_used.llm_provider == 'ollama'
-    assert cfg_used.ollama_url == 'http://10.1.1.1:11434/api/generate'
-    assert cfg_used.ollama_list_url == 'http://10.1.1.1:11434/api/tags'
+    assert "Final text:" in out
+    cfg_used = captured["config"]
+    assert cfg_used.llm_provider == "ollama"
+    assert cfg_used.ollama_url == "http://10.1.1.1:11434/api/generate"
+    assert cfg_used.ollama_list_url == "http://10.1.1.1:11434/api/tags"
 
 
 def test_cli_auto_mode_openai_endpoint(monkeypatch, tmp_path, capsys):
     cfg = Config(
-        log_dir=tmp_path / 'logs',
-        output_dir=tmp_path / 'output',
-        output_file='story.txt',
+        log_dir=tmp_path / "logs",
+        output_dir=tmp_path / "output",
+        output_file="story.txt",
     )
-    monkeypatch.setattr(agent, 'DEFAULT_CONFIG', cfg)
+    monkeypatch.setattr(agent, "DEFAULT_CONFIG", cfg)
 
     captured = {}
     original_writer = agent.WriterAgent
 
-    def capturing_writer(topic, word_count, steps, iterations, config, **kwargs):
-        captured['config'] = config
-        return original_writer(topic, word_count, steps, iterations, config, **kwargs)
+    def capturing_writer(topic, word_count, iterations, config, **kwargs):
+        captured["config"] = config
+        return original_writer(topic, word_count, iterations, config=config, **kwargs)
 
-    monkeypatch.setattr(agent, 'WriterAgent', capturing_writer)
+    monkeypatch.setattr(agent, "WriterAgent", capturing_writer)
 
     inputs = iter(
         [
-            'y',
-            'T',
-            'C',
-            'Report',
-            '',
-            '',
-            '',
-            '',
-            '',
-            '',
-            '',
-            '5',
-            '1',
-            'openai',
-            'gpt',
-            'http://custom',
+            "T",  # title
+            "C",  # content
+            "Report",  # text type
+            "",  # audience
+            "",  # tone
+            "",  # register
+            "",  # variant
+            "",  # constraints
+            "",  # sources allowed
+            "",  # seo keywords
+            "5",  # word count
+            "1",  # iterations
+            "openai",  # provider
+            "gpt",  # model
+            "http://custom",  # openai url
         ]
     )
-    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     cli.main()
 
     out = capsys.readouterr().out
-    assert 'Final text:' in out
-    cfg_used = captured['config']
-    assert cfg_used.llm_provider == 'openai'
-    assert cfg_used.model == 'gpt'
-    assert cfg_used.openai_url == 'http://custom'
+    assert "Final text:" in out
+    cfg_used = captured["config"]
+    assert cfg_used.llm_provider == "openai"
+    assert cfg_used.model == "gpt"
+    assert cfg_used.openai_url == "http://custom"
 
 
 def test_cli_keyboard_interrupt(monkeypatch, capsys):
     def raise_interrupt(_):
         raise KeyboardInterrupt
 
-    monkeypatch.setattr('builtins.input', raise_interrupt)
+    monkeypatch.setattr("builtins.input", raise_interrupt)
 
     cli.main()
 
     out = capsys.readouterr().out
-    assert 'Aborted.' in out
+    assert "Aborted." in out
+

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -8,7 +8,7 @@ from wordsmith.config import Config
 
 def test_logs_use_utf8(tmp_path):
     cfg = Config(log_dir=tmp_path / "logs", output_dir=tmp_path / "out")
-    writer = agent.WriterAgent("topic", 5, [], iterations=1, config=cfg)
+    writer = agent.WriterAgent("topic", 5, iterations=1, config=cfg)
     writer.logger.info("unicode \u2713")
     writer.llm_logger.info(json.dumps({"event": "prompt", "text": "\u4f60\u597d"}, ensure_ascii=False))
     run_data = (cfg.log_dir / cfg.log_file).read_bytes()
@@ -22,18 +22,3 @@ def test_logs_use_utf8(tmp_path):
         assert expected in text
     # Ensure llm log is valid JSON
     json.loads(llm_data.decode("utf-8").splitlines()[0])
-
-
-def test_logging_records_iteration(tmp_path):
-    cfg = Config(log_dir=tmp_path / "logs", output_dir=tmp_path / "out")
-    step = agent.Step(task="test")
-    writer = agent.WriterAgent("topic", 5, [step], iterations=1, config=cfg)
-    writer.run()
-    run_log = (cfg.log_dir / cfg.log_file).read_text("utf-8")
-    assert "iteration 1/1" in run_log
-    llm_lines = (cfg.log_dir / cfg.llm_log_file).read_text("utf-8").splitlines()
-    parsed = [json.loads(line) for line in llm_lines]
-    iterations = {entry["iteration"] for entry in parsed}
-    steps = {entry.get("step") for entry in parsed}
-    assert 1 in iterations
-    assert 1 in steps

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -3,30 +3,22 @@ from wordsmith import prompts
 
 def test_prompts_have_system_prompts():
     assert prompts.SYSTEM_PROMPT.strip()
-    assert prompts.META_SYSTEM_PROMPT.strip()
-    assert prompts.INITIAL_AUTO_SYSTEM_PROMPT.strip()
     assert prompts.IDEA_IMPROVEMENT_SYSTEM_PROMPT.strip()
     assert prompts.OUTLINE_SYSTEM_PROMPT.strip()
     assert prompts.OUTLINE_IMPROVEMENT_SYSTEM_PROMPT.strip()
     assert prompts.SECTION_SYSTEM_PROMPT.strip()
     assert prompts.REVISION_SYSTEM_PROMPT.strip()
-    assert prompts.PROMPT_CRAFTING_SYSTEM_PROMPT.strip()
-    assert prompts.STEP_SYSTEM_PROMPT.strip()
     assert prompts.TEXT_TYPE_CHECK_SYSTEM_PROMPT.strip()
     assert prompts.TEXT_TYPE_FIX_SYSTEM_PROMPT.strip()
 
 
 def test_system_prompts_quality_phrases():
     assert "Vermeide Wiederholungen und Füllwörter" in prompts.SYSTEM_PROMPT
-    assert "strukturierter Schreibcoach" in prompts.META_SYSTEM_PROMPT
-    assert "hochwertigen ersten Rohtext" in prompts.INITIAL_AUTO_SYSTEM_PROMPT
     assert "Rechtschreib- und Grammatikfehler" in prompts.IDEA_IMPROVEMENT_SYSTEM_PROMPT
     assert "klare Hierarchien" in prompts.OUTLINE_SYSTEM_PROMPT
     assert "Charakterisierung der Figuren" in prompts.OUTLINE_IMPROVEMENT_SYSTEM_PROMPT
     assert "konsequent im Stil" in prompts.SECTION_SYSTEM_PROMPT
     assert "Stil, Kohärenz und Grammatik" in prompts.REVISION_SYSTEM_PROMPT
-    assert "vermeidest Mehrdeutigkeiten" in prompts.PROMPT_CRAFTING_SYSTEM_PROMPT
-    assert "Figuren, Ton und Spannung" in prompts.STEP_SYSTEM_PROMPT
     assert "Merkmalen der angegebenen Textart" in prompts.TEXT_TYPE_CHECK_SYSTEM_PROMPT
     assert "Textchecks" in prompts.TEXT_TYPE_FIX_SYSTEM_PROMPT
 

--- a/wordsmith/cli.py
+++ b/wordsmith/cli.py
@@ -5,7 +5,6 @@ import json
 import urllib.error
 import urllib.request
 from urllib.parse import urlparse
-from typing import List
 
 import wordsmith.agent as agent
 
@@ -32,7 +31,7 @@ def _prompt_float(prompt: str, default: float | None = None) -> float:
             print("Invalid input. Please enter a number.")
 
 
-def _fetch_ollama_models(url: str) -> List[str]:
+def _fetch_ollama_models(url: str) -> list[str]:
     try:
         with urllib.request.urlopen(url) as resp:  # type: ignore[assignment]
             payload = json.loads(resp.read().decode("utf8"))
@@ -42,122 +41,37 @@ def _fetch_ollama_models(url: str) -> List[str]:
 
 
 def _run_cli() -> None:
-    if input("Automatic mode? (y/N): ").strip().lower() == "y":
-        default_topic = "Untitled"
-        topic = input(f"Title [{default_topic}]: ").strip() or default_topic
-        content = input("Desired content: ").strip()
-        text_type = input("Text type: ").strip() or "Text"
-        audience = (
-            input(
-                "Audience [Allgemeine Leserschaft mit Grundkenntnissen]: "
-            ).strip()
-            or "Allgemeine Leserschaft mit Grundkenntnissen"
-        )
-        tone = input("Tone [sachlich-lebendig]: ").strip() or "sachlich-lebendig"
-        register = input("Register [Sie]: ").strip() or "Sie"
-        variant = input("Variant [DE-DE]: ").strip() or "DE-DE"
-        constraints = input("Constraints (optional): ").strip()
-        sources_allowed = (
-            input("Sources allowed? (y/N): ").strip().lower() == "y"
-        )
-        seo_keywords = input("SEO keywords (optional): ").strip()
-        word_count = _prompt_int("Word count [100]: ", default=100)
-        iterations = _prompt_int("Number of iterations [1]: ", default=1)
-
-        default_provider = "ollama"
-        provider = (
-            input(
-                f"LLM provider (stub/ollama/openai) [{default_provider}]: "
-            ).strip()
-            or default_provider
-        )
-        if provider == "ollama":
-            default_ip = urlparse(agent.DEFAULT_CONFIG.ollama_url).hostname or ""
-            host_ip = input(f"Ollama host IP [{default_ip}]: ").strip() or default_ip
-            base_url = f"http://{host_ip}:11434"
-            ollama_url = f"{base_url}/api/generate"
-            list_url = f"{base_url}/api/tags"
-            models = _fetch_ollama_models(list_url)
-            if not models:
-                print("No models available from Ollama.")
-                return
-            print("Available models:")
-            for i, name in enumerate(models, 1):
-                print(f"{i}. {name}")
-            choice = _prompt_int("Select model [1]: ", default=1)
-            model = models[min(max(choice, 1), len(models)) - 1]
-            cfg = replace(
-                agent.DEFAULT_CONFIG,
-                llm_provider=provider,
-                model=model,
-                ollama_url=ollama_url,
-                ollama_list_url=list_url,
-            )
-        else:
-            model = (
-                input(f"Model name [{agent.DEFAULT_CONFIG.model}]: ").strip()
-                or agent.DEFAULT_CONFIG.model
-            )
-            if provider == "openai":
-                openai_url = (
-                    input(
-                        f"OpenAI API URL [{agent.DEFAULT_CONFIG.openai_url}]: "
-                    ).strip()
-                    or agent.DEFAULT_CONFIG.openai_url
-                )
-                cfg = replace(
-                    agent.DEFAULT_CONFIG,
-                    llm_provider=provider,
-                    model=model,
-                    openai_url=openai_url,
-                )
-            else:
-                cfg = replace(
-                    agent.DEFAULT_CONFIG, llm_provider=provider, model=model
-                )
-
-        writer = agent.WriterAgent(
-            topic,
-            word_count,
-            [],
-            iterations,
-            config=cfg,
-            content=content,
-            text_type=text_type,
-            audience=audience,
-            tone=tone,
-            register=register,
-            variant=variant,
-            constraints=constraints,
-            sources_allowed=sources_allowed,
-            seo_keywords=seo_keywords,
-        )
-        final_text = writer.run_auto()
-
-        print("\nFinal text:\n")
-        print(final_text)
-        return
-
     default_topic = "Untitled"
-    topic = input(f"Topic [{default_topic}]: ").strip() or default_topic
+    topic = input(f"Title [{default_topic}]: ").strip() or default_topic
+    content = input("Desired content: ").strip()
+    text_type = input("Text type: ").strip() or "Text"
+    audience = (
+        input("Audience [Allgemeine Leserschaft mit Grundkenntnissen]: ").strip()
+        or "Allgemeine Leserschaft mit Grundkenntnissen"
+    )
+    tone = input("Tone [sachlich-lebendig]: ").strip() or "sachlich-lebendig"
+    register = input("Register [Sie]: ").strip() or "Sie"
+    variant = input("Variant [DE-DE]: ").strip() or "DE-DE"
+    constraints = input("Constraints (optional): ").strip()
+    sources_allowed = input("Sources allowed? (y/N): ").strip().lower() == "y"
+    seo_keywords = input("SEO keywords (optional): ").strip()
     word_count = _prompt_int("Word count [100]: ", default=100)
-    step_count = _prompt_int("Number of steps [1]: ", default=1)
-    iterations = _prompt_int("Iterations per step [1]: ", default=1)
+    iterations = _prompt_int("Number of iterations [1]: ", default=1)
 
-    steps: List[agent.Step] = []
-    for i in range(1, step_count + 1):
-        default_task = f"Step {i}"
-        task = input(f"Task for step {i} [{default_task}]: ").strip() or default_task
-        steps.append(agent.Step(task))
-
+    default_provider = "ollama"
     provider = (
         input(
-            f"LLM provider (stub/ollama/openai) [{agent.DEFAULT_CONFIG.llm_provider}]: "
+            f"LLM provider (stub/ollama/openai) [{default_provider}]: "
         ).strip()
-        or agent.DEFAULT_CONFIG.llm_provider
+        or default_provider
     )
     if provider == "ollama":
-        models = _fetch_ollama_models(agent.DEFAULT_CONFIG.ollama_list_url)
+        default_ip = urlparse(agent.DEFAULT_CONFIG.ollama_url).hostname or ""
+        host_ip = input(f"Ollama host IP [{default_ip}]: ").strip() or default_ip
+        base_url = f"http://{host_ip}:11434"
+        ollama_url = f"{base_url}/api/generate"
+        list_url = f"{base_url}/api/tags"
+        models = _fetch_ollama_models(list_url)
         if not models:
             print("No models available from Ollama.")
             return
@@ -166,34 +80,52 @@ def _run_cli() -> None:
             print(f"{i}. {name}")
         choice = _prompt_int("Select model [1]: ", default=1)
         model = models[min(max(choice, 1), len(models)) - 1]
+        cfg = replace(
+            agent.DEFAULT_CONFIG,
+            llm_provider=provider,
+            model=model,
+            ollama_url=ollama_url,
+            ollama_list_url=list_url,
+        )
     else:
         model = (
             input(f"Model name [{agent.DEFAULT_CONFIG.model}]: ").strip()
             or agent.DEFAULT_CONFIG.model
         )
-    temperature = _prompt_float(
-        f"Temperature [{agent.DEFAULT_CONFIG.temperature}]: ",
-        default=agent.DEFAULT_CONFIG.temperature,
-    )
-    context_length = _prompt_int(
-        f"Context length [{agent.DEFAULT_CONFIG.context_length}]: ",
-        default=agent.DEFAULT_CONFIG.context_length,
-    )
-    max_tokens = _prompt_int(
-        f"Max tokens [{agent.DEFAULT_CONFIG.max_tokens}]: ",
-        default=agent.DEFAULT_CONFIG.max_tokens,
-    )
+        if provider == "openai":
+            openai_url = (
+                input(
+                    f"OpenAI API URL [{agent.DEFAULT_CONFIG.openai_url}]: "
+                ).strip()
+                or agent.DEFAULT_CONFIG.openai_url
+            )
+            cfg = replace(
+                agent.DEFAULT_CONFIG,
+                llm_provider=provider,
+                model=model,
+                openai_url=openai_url,
+            )
+        else:
+            cfg = replace(
+                agent.DEFAULT_CONFIG, llm_provider=provider, model=model
+            )
 
-    cfg = replace(
-        agent.DEFAULT_CONFIG,
-        llm_provider=provider,
-        model=model,
-        temperature=temperature,
-        context_length=context_length,
-        max_tokens=max_tokens,
+    writer = agent.WriterAgent(
+        topic,
+        word_count,
+        iterations,
+        config=cfg,
+        content=content,
+        text_type=text_type,
+        audience=audience,
+        tone=tone,
+        register=register,
+        variant=variant,
+        constraints=constraints,
+        sources_allowed=sources_allowed,
+        seo_keywords=seo_keywords,
     )
-    writer = agent.WriterAgent(topic, word_count, steps, iterations, config=cfg)
-    final_text = writer.run()
+    final_text = writer.run_auto()
 
     print("\nFinal text:\n")
     print(final_text)

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -9,30 +9,6 @@ SYSTEM_PROMPT = (
     "Dein Thema lautet: {topic}. Du verfasst einen {text_type}."
 )
 
-# Prompts for interactive/legacy features remain largely unchanged
-META_SYSTEM_PROMPT = (
-    "Du bist ein kreativer, strukturierter Schreibcoach, der Autorinnen hilft, den nächsten "
-    "sinnvollen Schritt zu planen und ihre Texte zu verfeinern."
-)
-
-META_PROMPT = (
-    "Du arbeitest an einem {text_type} mit dem Titel: {title}\n"
-    "Er behandelt folgenden Inhalt: {content}\n"
-    "Die gewünschte Länge beträgt etwa {word_count} Wörter.\n"
-    "Aktueller Stand des Textes:\n{current_text}\n\n"
-    "Beschreibe den nächsten sinnvollen Schritt der Geschichte, der den Text literarisch vertiefen würde. "
-    "Achte darauf, dass Atmosphäre, Spannung und innere Konflikte verstärkt werden und die Figuren "
-    "lebendiger, widersprüchlicher und psychologisch nachvollziehbarer wirken. "
-    "Lege Wert auf subtile Andeutungen, emotionale Zwischentöne und mögliche symbolische Elemente, "
-    "die den Text dichter und vielschichtiger machen. "
-    "Formuliere ausschließlich einen präzisen Prompt für ein LLM, der genau diesen nächsten sinnvollen Schritt beschreibt, "
-    "so dass daraus eine kreative und literarisch hochwertige Erweiterung der Geschichte entstehen kann."
-)
-
-INITIAL_AUTO_SYSTEM_PROMPT = (
-    "Du bist eine erfahrene Autorin, die aus kurzen Vorgaben einen hochwertigen ersten Rohtext entwickelt."
-)
-
 # ---------------------------------------------------------------------------
 # Prompts for the revised automatic mode
 
@@ -114,27 +90,6 @@ REVISION_PROMPT = (
     "Aktueller Text:\n{current_text}\n\nÜberarbeiteter Text:"
 )
 
-# ---------------------------------------------------------------------------
-# Remaining prompts used by the interactive mode and helper utilities
-
-PROMPT_CRAFTING_SYSTEM_PROMPT = (
-    "Du formulierst knappe, klare Prompts für andere Sprachmodelle und vermeidest Mehrdeutigkeiten."
-)
-
-PROMPT_CRAFTING_PROMPT = (
-    "Formuliere einen klaren und konkreten Prompt für ein LLM, "
-    "um die Aufgabe '{task}' zum Thema '{topic}' umzusetzen. "
-    "Gib nur den Prompt zurück."
-)
-
-STEP_SYSTEM_PROMPT = (
-    "Du führst als erfahrene Autorin eine begonnene Erzählung stilgetreu fort und greifst Figuren, Ton und Spannung des bisherigen Textes auf."
-)
-
-STEP_PROMPT = (
-    "{prompt}\n\nAktueller Text:\n{current_text}\n\nNächster Abschnitt:"
-)
-
 TEXT_TYPE_CHECK_SYSTEM_PROMPT = (
     "Du prüfst als seit 20 Jahren erfahrene Lektorin Texte darauf, ob sie den Merkmalen der angegebenen Textart entsprechen."
 )
@@ -153,9 +108,5 @@ TEXT_TYPE_FIX_PROMPT = (
     "{issues}\n"
     "Behebe sie im folgenden Text und liefere die verbesserte Version:\n"
     "{current_text}\n"
-)
-
-REFLECTION_PROMPT = (
-    "Nenne die 3 wirksamsten nächsten Verbesserungen (knapp, umsetzbar)."
 )
 


### PR DESCRIPTION
## Summary
- drop step-based interactive mode from WriterAgent and CLI
- keep only automatic generation prompts and update docs for automatic workflow
- adjust tests to cover automatic mode usage exclusively

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b02e8b935883258237e57eb123bd0d