### PR TITLE
fix: avoid repeated section text

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -183,6 +183,22 @@ def test_generate_sections_from_outline_dedupes_repeated_text(monkeypatch, tmp_p
     assert full.strip() == 'alpha beta gamma delta'
 
 
+def test_generate_sections_from_outline_dedupes_with_newline(monkeypatch, tmp_path):
+    cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'out')
+    writer = agent.WriterAgent('Topic', 4, iterations=0, config=cfg)
+    outline = '1. Intro | Rolle: Hook | Wortbudget: 4 | Liefergegenstand: Start'
+
+    responses = iter(['alpha beta', '\nalpha beta gamma delta'])
+
+    def fake_call(self, prompt, *, fallback, system_prompt=None):
+        return next(responses)
+
+    monkeypatch.setattr(agent.WriterAgent, '_call_llm', fake_call)
+
+    limited, full = writer._generate_sections_from_outline(outline, '{}')
+    assert full.strip() == 'alpha beta gamma delta'
+
+
 def test_run_auto_creates_briefing_and_metadata(monkeypatch, tmp_path):
     cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'out')
     writer = agent.WriterAgent(

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -372,11 +372,17 @@ class WriterAgent:
     # ------------------------------------------------------------------
     def _remove_overlap(self, existing: str, new: str) -> str:
         """Remove any overlapping prefix from ``new`` that repeats ``existing``."""
-
         if not existing or not new:
             return new
+
+        # Normalise whitespace so that differences in leading/trailing spaces or
+        # newlines do not prevent overlap detection.
+        existing = existing.rstrip()
+        new = new.lstrip()
+
         if new.startswith(existing):
             return new[len(existing):].lstrip()
+
         max_overlap = min(len(existing), len(new))
         for i in range(max_overlap, 0, -1):
             if existing.endswith(new[:i]):


### PR DESCRIPTION
## Summary
- deduplicate language-model continuations so repeated prefixes aren't re-added
- add regression test ensuring repeated text is removed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b039d41e6c83258efb2ca7089c02d9