### PR TITLE
Improve short-text handling by deepening full story

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -148,13 +148,13 @@ def test_generate_sections_from_outline_extends_short_sections(monkeypatch, tmp_
     assert len(prompts_seen) == 2
 
 
-def test_generate_sections_from_outline_extends_final_section(monkeypatch, tmp_path):
+def test_generate_sections_from_outline_expands_full_text(monkeypatch, tmp_path):
     cfg = Config(log_dir=tmp_path / 'logs', output_dir=tmp_path / 'out')
     writer = agent.WriterAgent('Topic', 5, iterations=0, config=cfg)
     outline = '1. Intro | Rolle: Hook | Wortbudget: 5 | Liefergegenstand: Start'
 
     prompts_seen = []
-    responses = iter(['kurz', '', 'jetzt kommen genug worte'])
+    responses = iter(['kurz', 'jetzt kommen genug worte hier'])
 
     def fake_call(self, prompt, *, fallback, system_prompt=None):
         prompts_seen.append(prompt)
@@ -164,7 +164,8 @@ def test_generate_sections_from_outline_extends_final_section(monkeypatch, tmp_p
 
     limited, full = writer._generate_sections_from_outline(outline, '{}')
     assert len(full.split()) >= 5
-    assert len(prompts_seen) == 3
+    assert len(prompts_seen) == 2
+    assert 'kurz' in prompts_seen[1]
 
 
 def test_run_auto_creates_briefing_and_metadata(monkeypatch, tmp_path):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -10,6 +10,7 @@ def test_prompts_have_system_prompts():
     assert prompts.REVISION_SYSTEM_PROMPT.strip()
     assert prompts.TEXT_TYPE_CHECK_SYSTEM_PROMPT.strip()
     assert prompts.TEXT_TYPE_FIX_SYSTEM_PROMPT.strip()
+    assert prompts.STORY_DEEPENING_SYSTEM_PROMPT.strip()
 
 
 def test_system_prompts_quality_phrases():
@@ -21,6 +22,7 @@ def test_system_prompts_quality_phrases():
     assert "Stil, Kohärenz und Grammatik" in prompts.REVISION_SYSTEM_PROMPT
     assert "Merkmalen der angegebenen Textart" in prompts.TEXT_TYPE_CHECK_SYSTEM_PROMPT
     assert "Textchecks" in prompts.TEXT_TYPE_FIX_SYSTEM_PROMPT
+    assert "vertiefst die Geschichte" in prompts.STORY_DEEPENING_SYSTEM_PROMPT
 
 
 def test_outline_prompt_mentions_briefing():

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -340,31 +340,20 @@ class WriterAgent:
             )
         print()
         current_full = "\n\n".join(full_parts)
-        if len(current_full.split()) < self.word_count and allocated:
-            title, role, _, deliverable = allocated[-1]
-            idx = len(allocated)
-            while len(current_full.split()) < self.word_count:
-                remaining = self.word_count - len(current_full.split())
-                recap = " ".join(current_full.split()[-20:])
-                continue_prompt = prompts.SECTION_CONTINUE_PROMPT.format(
-                    section_number=idx,
-                    section_title=title,
-                    role=role,
-                    deliverable=deliverable,
-                    budget=remaining,
-                    briefing_json=briefing_json,
-                    previous_section_recap=recap,
-                    existing_text=full_parts[-1],
-                )
-                extra = self._call_llm(
-                    continue_prompt,
-                    fallback="",
-                    system_prompt=prompts.SECTION_SYSTEM_PROMPT,
-                ).strip()
-                if not extra:
-                    break
-                full_parts[-1] = f"{full_parts[-1]} {extra}".strip()
-                current_full = "\n\n".join(full_parts)
+        if len(current_full.split()) < self.word_count:
+            remaining = self.word_count - len(current_full.split())
+            deepen_prompt = prompts.STORY_DEEPENING_PROMPT.format(
+                remaining=remaining,
+                briefing_json=briefing_json,
+                current_text=current_full,
+            )
+            expanded = self._call_llm(
+                deepen_prompt,
+                fallback=current_full,
+                system_prompt=prompts.STORY_DEEPENING_SYSTEM_PROMPT,
+            ).strip()
+            if expanded:
+                current_full = expanded
         return self._truncate_text(current_full), current_full
 
     # ------------------------------------------------------------------

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -79,6 +79,16 @@ SECTION_CONTINUE_PROMPT = (
     "Bisheriger Kontext (Kurz-Recap): {previous_section_recap}"
 )
 
+STORY_DEEPENING_SYSTEM_PROMPT = (
+    "Du überarbeitest Texte und vertiefst die Geschichte, indem du Details ergänzt und eine stimmige Dramaturgie sicherstellst."
+)
+
+STORY_DEEPENING_PROMPT = (
+    "Der Text ist insgesamt noch zu kurz. Überarbeite den gesamten Text, vertiefe die Geschichte und füge etwa {remaining} zusätzliche Wörter ein, ohne nur den Schluss aufzublähen.\n"
+    "Briefing: {briefing_json}\n"
+    "Aktueller Text:\n{current_text}\n"
+)
+
 REVISION_SYSTEM_PROMPT = (
     "Du überarbeitest Texte präzise, verbesserst Stil, Kohärenz und Grammatik und orientierst dich an einer vorgegebenen Outline."
 )


### PR DESCRIPTION
## Summary
- Add `STORY_DEEPENING_*` prompts to expand underlength drafts by revising the whole story
- Revise section generation to call new prompt when overall text is too short
- Test full-text expansion and ensure new prompts are documented

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b04c04e8b083259d3a0e692b2e36d4