### PR TITLE
Ensure section prompt returns only new text

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -48,6 +48,7 @@ def test_section_prompt_mentions_briefing():
     )
     assert 'Briefing' in text
     assert 'Zielwortzahl' in text
+    assert 'neu generierten Abschnittstext' in text
 
 
 def test_text_type_fix_prompt_mentions_issues():

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -68,7 +68,8 @@ SECTION_PROMPT = (
     "Briefing: {briefing_json}\n"
     "Bisheriger Kontext (Kurz-Recap): {previous_section_recap}\n"
     "Regeln: aktive Verben, keine Füllphrasen, natürliche Übergänge, keine erfundenen Fakten (Platzhalter bei Lücken).\n"
-    "Zielwortzahl: {budget}."
+    "Zielwortzahl: {budget}.\n"
+    "Gib ausschließlich den neu generierten Abschnittstext aus."
 )
 
 SECTION_CONTINUE_PROMPT = (


### PR DESCRIPTION
## Summary
- make section prompt output only newly generated section text
- verify section prompt change with extended test coverage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b06e6fba2c832582b5888c7f4e91d5