### PR TITLE
Clarify CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ python -m wordsmith.cli
 ```
 
 The program will prompt for details such as title, desired content, text type,
-audience, tone, register, variant, optional constraints and keywords, desired
-word count, revision count, and LLM provider (stub/Ollama/OpenAI). When using
-Ollama the available models are listed for selection. Each prompt displays a
-default in square brackets and pressing Enter accepts it.
+audience, tone, register, variant, optional constraints, whether sources may be
+used, optional SEO keywords, desired word count, revision count, and LLM
+provider (stub/ollama/openai). When using Ollama you are asked for the host IP
+and to choose a model from the available list. Selecting OpenAI lets you supply
+a custom API URL. Each prompt displays a default in square brackets and pressing
+Enter accepts it.
 
-During execution a log is written to `logs/run.log` and the evolving text is
-stored in `output/current_text.txt`.
+During execution logs are written to `logs/run.log` and `logs/llm.log` while the
+evolving text is stored in `output/current_text.txt`.


### PR DESCRIPTION
## Summary
- detail CLI prompts including source usage, SEO keywords, provider-specific options, and logging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b13392d87483258256fa52c6fb861f