### PR TITLE
docs: expand automatic mode description

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,25 @@ documentation.
 
 ## Automatic Mode
 
-Execute the CLI in its automatic mode:
+The automatic mode is intended for unattended processing. Executing the
+CLI triggers a fixed pipeline that transforms an input file into an
+output file without requiring user interaction.
+
+1. **Load configuration** – default settings such as model parameters and
+   output paths are read from `wordsmith/config.py`.
+2. **Load prompts** – templates that drive text generation are imported
+   from `wordsmith/prompts.py`.
+3. **Read input** – the program searches for `input/input.txt` or accepts
+   data from `stdin`.
+4. **Generate output** – the transformed text is written to
+   `output/output.txt` and echoed to `stdout`.
+5. **Exit status** – the CLI returns `0` on success and a non‑zero code on
+   error.
+
+Run the CLI in its automatic mode with:
 
 ```bash
 python cli.py
 ```
 
-This command starts WordSmith using the built-in defaults.
+This command executes the entire pipeline using the built‑in defaults.


### PR DESCRIPTION
## Summary
- document automatic processing pipeline for WordSmith's sole operation mode

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c826f88c7c832582bbb2b9fe890f61