### PR TITLE
Implement automatikmodus CLI pipeline

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,8 +1,204 @@
-"""Dummy CLI entry point for the new WordSmith project."""
+"""Command line interface for the WordSmith automatikmodus."""
 
-def main() -> None:
-    """Placeholder main function."""
-    print("WordSmith CLI is under construction.")
+from __future__ import annotations
 
-if __name__ == "__main__":
-    main()
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+from wordsmith import prompts
+from wordsmith.agent import WriterAgent, WriterAgentError
+from wordsmith.config import ConfigError, load_config
+
+DEFAULT_AUDIENCE = "Allgemeine Leserschaft mit Grundkenntnissen"
+DEFAULT_TONE = "sachlich-lebendig"
+DEFAULT_REGISTER = "Sie"
+DEFAULT_VARIANT = "DE-DE"
+
+
+def _parse_bool(value: str) -> bool:
+    truthy = {"true", "1", "yes", "ja"}
+    falsy = {"false", "0", "no", "nein"}
+    value_normalised = value.strip().lower()
+    if value_normalised in truthy:
+        return True
+    if value_normalised in falsy:
+        return False
+    raise argparse.ArgumentTypeError(
+        "Wert muss 'ja'/'nein' beziehungsweise 'true'/'false' sein."
+    )
+
+
+def _parse_keywords(value: str) -> List[str]:
+    if not value:
+        return []
+    return [keyword.strip() for keyword in value.split(",") if keyword.strip()]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="wordsmith",
+        description="Automatisierte Textproduktion gemäß Automatikmodus-Dokumentation.",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    automatik_parser = subparsers.add_parser(
+        "automatikmodus",
+        help="Starte den Automatikmodus und schreibe alle Ausgabedateien.",
+    )
+    automatik_parser.add_argument("--title", required=True, help="Arbeitstitel des Textes.")
+    automatik_parser.add_argument(
+        "--content",
+        required=True,
+        help="Briefing oder Notizen, die in den Prozess einfließen.",
+    )
+    automatik_parser.add_argument(
+        "--text-type",
+        required=True,
+        dest="text_type",
+        help="Texttyp, z. B. Blogartikel, Pressemitteilung, Produktbeschreibung.",
+    )
+    automatik_parser.add_argument(
+        "--word-count",
+        required=True,
+        type=int,
+        dest="word_count",
+        help="Zielwortzahl für den finalen Text.",
+    )
+    automatik_parser.add_argument(
+        "--iterations",
+        type=int,
+        default=1,
+        help="Anzahl der Überarbeitungsdurchläufe.",
+    )
+    automatik_parser.add_argument(
+        "--llm-provider",
+        default="mock-provider",
+        dest="llm_provider",
+        help="Bezeichner des verwendeten LLM-Anbieters.",
+    )
+    automatik_parser.add_argument(
+        "--audience",
+        default=DEFAULT_AUDIENCE,
+        help="Adressierte Zielgruppe (Default: allgemeine Leserschaft).",
+    )
+    automatik_parser.add_argument(
+        "--tone",
+        default=DEFAULT_TONE,
+        help="Gewünschter Tonfall, z. B. sachlich, lebendig.",
+    )
+    automatik_parser.add_argument(
+        "--register",
+        default=DEFAULT_REGISTER,
+        help="Sprachregister bzw. Anrede (Du/Sie).",
+    )
+    automatik_parser.add_argument(
+        "--variant",
+        default=DEFAULT_VARIANT,
+        help="Sprachvariante, z. B. DE-DE, DE-AT oder DE-CH.",
+    )
+    automatik_parser.add_argument(
+        "--constraints",
+        default="",
+        help="Zusätzliche Muss-/Kann-Vorgaben für den Text.",
+    )
+    automatik_parser.add_argument(
+        "--sources-allowed",
+        type=_parse_bool,
+        default=False,
+        dest="sources_allowed",
+        help="Ob Quellenangaben erlaubt sind (ja/nein).",
+    )
+    automatik_parser.add_argument(
+        "--seo-keywords",
+        type=_parse_keywords,
+        default=[],
+        dest="seo_keywords",
+        help="Kommagetrennte Liste relevanter SEO-Schlüsselwörter.",
+    )
+    automatik_parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Pfad zu einer optionalen JSON-Konfigurationsdatei.",
+    )
+    automatik_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Ausgabeverzeichnis (überschreibt Konfiguration).",
+    )
+    automatik_parser.add_argument(
+        "--logs-dir",
+        type=Path,
+        default=None,
+        help="Log-Verzeichnis (überschreibt Konfiguration).",
+    )
+    automatik_parser.set_defaults(func=_run_automatikmodus)
+    return parser
+
+
+def _run_automatikmodus(args: argparse.Namespace) -> int:
+    try:
+        config = load_config(args.config)
+    except ConfigError as exc:
+        print(f"Konfiguration konnte nicht geladen werden: {exc}", file=sys.stderr)
+        return 2
+
+    if args.output_dir is not None:
+        config.output_dir = Path(args.output_dir)
+    if args.logs_dir is not None:
+        config.logs_dir = Path(args.logs_dir)
+    config.llm_provider = args.llm_provider
+
+    try:
+        config.adjust_for_word_count(args.word_count)
+    except ConfigError as exc:
+        print(f"Ungültige Einstellung: {exc}", file=sys.stderr)
+        return 2
+
+    prompts.set_system_prompt(config.system_prompt)
+
+    agent = WriterAgent(
+        topic=args.title,
+        word_count=args.word_count,
+        steps=[],
+        iterations=args.iterations,
+        config=config,
+        content=args.content,
+        text_type=args.text_type,
+        audience=args.audience,
+        tone=args.tone,
+        register=args.register,
+        variant=args.variant,
+        constraints=args.constraints,
+        sources_allowed=args.sources_allowed,
+        seo_keywords=args.seo_keywords,
+    )
+
+    try:
+        final_text = agent.run()
+    except WriterAgentError as exc:
+        print(f"Automatikmodus konnte nicht abgeschlossen werden: {exc}", file=sys.stderr)
+        return 1
+
+    print(final_text)
+    return 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    arguments = list(argv) if argv is not None else sys.argv[1:]
+    if not arguments:
+        parser.print_help()
+        return 1
+    parsed = parser.parse_args(arguments)
+    if hasattr(parsed, "func"):
+        return parsed.func(parsed)
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,15 +1,98 @@
-import io
-import contextlib
+import json
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from cli import main
+from wordsmith import prompts
 
 
-def test_cli_main_outputs_message():
-    buffer = io.StringIO()
-    with contextlib.redirect_stdout(buffer):
-        main()
-    assert "WordSmith CLI is under construction." in buffer.getvalue()
+def test_automatikmodus_requires_arguments():
+    with pytest.raises(SystemExit) as exc:
+        main(["automatikmodus"])
+    assert exc.value.code == 2
+
+
+def test_automatikmodus_runs_and_creates_outputs(tmp_path, capsys):
+    output_dir = tmp_path / "output"
+    logs_dir = tmp_path / "logs"
+    args = [
+        "automatikmodus",
+        "--title",
+        "Strategische Roadmap",
+        "--content",
+        "Wir brauchen eine klare Roadmap für das nächste Quartal.",
+        "--text-type",
+        "Blogartikel",
+        "--word-count",
+        "600",
+        "--iterations",
+        "2",
+        "--llm-provider",
+        "provider-x",
+        "--audience",
+        "Marketing-Team",
+        "--tone",
+        "faktenbasiert",
+        "--register",
+        "Du",
+        "--variant",
+        "DE-AT",
+        "--constraints",
+        "Keine vertraulichen Zahlen nennen.",
+        "--sources-allowed",
+        "ja",
+        "--seo-keywords",
+        "roadmap, marketing",
+        "--output-dir",
+        str(output_dir),
+        "--logs-dir",
+        str(logs_dir),
+    ]
+
+    exit_code = main(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Strategische Roadmap" in captured.out
+
+    current_text = (output_dir / "current_text.txt").read_text(encoding="utf-8")
+    assert "Strategische Roadmap" in current_text
+    assert "Systemprompt" in current_text
+
+    iteration_file = output_dir / "iteration_02.txt"
+    assert iteration_file.exists()
+
+    metadata = json.loads((output_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["title"] == "Strategische Roadmap"
+    assert metadata["sources_allowed"] is True
+    assert metadata["system_prompt"] == prompts.SYSTEM_PROMPT
+
+    briefing = json.loads((output_dir / "briefing.json").read_text(encoding="utf-8"))
+    assert "seo_keywords" in briefing
+    assert "roadmap" in briefing["seo_keywords"]
+
+    assert (logs_dir / "run.log").exists()
+    assert (logs_dir / "llm.log").exists()
+
+
+def test_invalid_sources_allowed_value_raises_help():
+    args = [
+        "automatikmodus",
+        "--title",
+        "Test",
+        "--content",
+        "Inhalt",
+        "--text-type",
+        "Blog",
+        "--word-count",
+        "500",
+        "--sources-allowed",
+        "vielleicht",
+    ]
+    with pytest.raises(SystemExit) as exc:
+        main(args)
+    assert exc.value.code == 2

--- a/wordsmith/__init__.py
+++ b/wordsmith/__init__.py
@@ -1,0 +1,15 @@
+"""WordSmith package exports core components for the CLI."""
+
+from .config import Config, ConfigError, LLMParameters, load_config
+from .agent import WriterAgent, WriterAgentError
+from . import prompts
+
+__all__ = [
+    "Config",
+    "ConfigError",
+    "LLMParameters",
+    "WriterAgent",
+    "WriterAgentError",
+    "load_config",
+    "prompts",
+]

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -1,0 +1,252 @@
+"""Simplified implementation of the Automatikmodus writer agent."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import List, Sequence
+
+from . import prompts
+from .config import Config
+
+
+class WriterAgentError(Exception):
+    """Raised when the writer agent cannot complete its work."""
+
+
+@dataclass
+class WriterAgent:
+    """Deterministic mock implementation that mirrors the documented pipeline."""
+
+    topic: str
+    word_count: int
+    steps: Sequence[str] | None
+    iterations: int
+    config: Config
+    content: str
+    text_type: str
+    audience: str
+    tone: str
+    register: str
+    variant: str
+    constraints: str
+    sources_allowed: bool
+    seo_keywords: Sequence[str] | None = None
+
+    output_dir: Path = field(init=False)
+    logs_dir: Path = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.word_count <= 0:
+            raise WriterAgentError("`word_count` muss größer als 0 sein.")
+        if self.iterations < 0:
+            raise WriterAgentError("`iterations` darf nicht negativ sein.")
+        self.steps = list(self.steps or [])
+        self.seo_keywords = [kw.strip() for kw in (self.seo_keywords or []) if kw.strip()]
+        self.output_dir = Path(self.config.output_dir)
+        self.logs_dir = Path(self.config.logs_dir)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run(self) -> str:
+        """Execute the documented pipeline and return the final text."""
+
+        self.config.ensure_directories()
+        briefing = self._create_briefing()
+        self._write_json(self.output_dir / "briefing.json", briefing)
+
+        idea = self._improve_idea()
+        self._write_text(self.output_dir / "idea.txt", idea)
+
+        outline = self._create_outline()
+        self._write_text(self.output_dir / "outline.txt", outline)
+
+        initial_draft = self._compose_draft(briefing, idea, outline)
+        self._write_text(self.output_dir / "iteration_00.txt", initial_draft)
+
+        current = initial_draft
+        for iteration in range(1, self.iterations + 1):
+            current = self._revise_draft(current, iteration)
+            self._write_text(self.output_dir / f"iteration_{iteration:02d}.txt", current)
+
+        self._write_text(self.output_dir / "current_text.txt", current)
+        self._write_metadata(current)
+        self._write_logs(briefing)
+        return current
+
+    # ------------------------------------------------------------------
+    # Pipeline steps
+    # ------------------------------------------------------------------
+    def _create_briefing(self) -> dict:
+        key_terms = self._extract_key_terms()
+        messages = [line.strip() for line in self.content.splitlines() if line.strip()]
+        if not messages:
+            messages = ["[KLÄREN: Es wurden keine Notizen geliefert.]"]
+
+        briefing = {
+            "goal": f"{self.text_type} zu '{self.topic}' präzise ausarbeiten",
+            "audience": self.audience,
+            "tone": self.tone,
+            "register": self.register,
+            "variant": self.variant,
+            "constraints": self.constraints or "Keine zusätzlichen Vorgaben",
+            "key_terms": key_terms,
+            "messages": messages,
+        }
+        if self.seo_keywords:
+            briefing["seo_keywords"] = list(self.seo_keywords)
+        return briefing
+
+    def _improve_idea(self) -> str:
+        sentences = [line.strip() for line in self.content.splitlines() if line.strip()]
+        bullets = "\n".join(f"- {sentence}" for sentence in sentences)
+        summary = (
+            f"Zusammenfassung: Der Text richtet sich an {self.audience} und verfolgt das Ziel, "
+            f"{self.text_type} mit dem Fokus '{self.topic}' zu liefern."
+        )
+        if not bullets:
+            bullets = "- [KLÄREN: Inhaltliches Briefing ergänzen]"
+        return "\n".join(
+            [
+                f"Überarbeitete Idee für '{self.topic}':",
+                bullets,
+                "",
+                summary,
+            ]
+        )
+
+    def _create_outline(self) -> str:
+        intro_budget, body_budget, outro_budget = self._section_budgets()
+        sections = [
+            (
+                "1",
+                "Einstieg mit Kontext",
+                "Hook",
+                intro_budget,
+                "Rahmen und Relevanz für die Zielgruppe klären.",
+            ),
+            (
+                "2",
+                "Vertiefung der Kernaussagen",
+                "Argument",
+                body_budget,
+                "Zentrale Botschaften strukturiert ausarbeiten.",
+            ),
+            (
+                "3",
+                "Fazit und Ausblick",
+                "CTA",
+                outro_budget,
+                "Handlungsimpuls geben und Nutzen verdichten.",
+            ),
+        ]
+        outline_lines = [
+            f"{number}. {title} (Rolle: {role}, Budget: {budget} Wörter) -> {deliverable}"
+            for number, title, role, budget, deliverable in sections
+        ]
+        return "\n".join(outline_lines)
+
+    def _compose_draft(self, briefing: dict, idea: str, outline: str) -> str:
+        keywords_line = (
+            "SEO-Schlüsselwörter: " + ", ".join(self.seo_keywords)
+            if self.seo_keywords
+            else "SEO-Schlüsselwörter: –"
+        )
+        draft_parts = [
+            self.topic,
+            "",
+            f"Zielgruppe: {briefing['audience']} ({briefing['variant']}).",
+            f"Ton und Register: {briefing['tone']} | {briefing['register']}.",
+            f"Rahmenbedingungen: {briefing['constraints']}.",
+            "",
+            "Kernaussagen aus dem Briefing:",
+            "\n".join(f"- {msg}" for msg in briefing["messages"]),
+            "",
+            "Überarbeitete Idee:",
+            idea,
+            "",
+            "Outline für den Text:",
+            outline,
+            "",
+            keywords_line,
+            "",
+            f"Systemprompt: {prompts.SYSTEM_PROMPT}",
+        ]
+        return "\n".join(draft_parts)
+
+    def _revise_draft(self, current: str, iteration: int) -> str:
+        return (
+            current
+            + "\n\n"
+            + f"[Überarbeitung {iteration:02d}: Textfluss und Terminologie für {self.audience} verfeinert.]"
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _section_budgets(self) -> tuple[int, int, int]:
+        intro = max(80, int(self.word_count * 0.2))
+        outro = max(60, int(self.word_count * 0.2))
+        body = max(120, self.word_count - intro - outro)
+        if body < 0:
+            body = max(0, self.word_count)
+        return intro, body, outro
+
+    def _extract_key_terms(self) -> List[str]:
+        terms = set()
+        for token in self.content.replace("\n", " ").split():
+            token = token.strip().strip(",.;:!?()[]{}" "\"'").lower()
+            if len(token) > 4:
+                terms.add(token)
+        return sorted(terms)
+
+    def _write_json(self, path: Path, data: dict) -> None:
+        path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    def _write_text(self, path: Path, text: str) -> None:
+        path.write_text(text.strip() + "\n", encoding="utf-8")
+
+    def _write_metadata(self, text: str) -> None:
+        metadata = {
+            "title": self.topic,
+            "audience": self.audience,
+            "tone": self.tone,
+            "register": self.register,
+            "variant": self.variant,
+            "keywords": self.seo_keywords,
+            "final_word_count": self._count_words(text),
+            "rubric_passed": True,
+            "sources_allowed": self.sources_allowed,
+            "llm_provider": self.config.llm_provider,
+            "system_prompt": prompts.SYSTEM_PROMPT,
+        }
+        self._write_json(self.output_dir / "metadata.json", metadata)
+
+    def _write_logs(self, briefing: dict) -> None:
+        run_log = self.logs_dir / "run.log"
+        log_lines = [
+            "Automatikmodus gestartet",
+            f"Thema: {self.topic}",
+            f"Zielwortzahl: {self.word_count}",
+            "Briefing erstellt und gespeichert",
+            "Outline und Text erstellt",
+            "Automatikmodus erfolgreich abgeschlossen",
+        ]
+        run_log.write_text("\n".join(log_lines) + "\n", encoding="utf-8")
+
+        llm_log = self.logs_dir / "llm.log"
+        llm_entry = {
+            "provider": self.config.llm_provider,
+            "parameters": asdict(self.config.llm),
+            "system_prompt": prompts.SYSTEM_PROMPT,
+            "topic": self.topic,
+            "word_count": self.word_count,
+            "audience": self.audience,
+            "messages": briefing["messages"],
+        }
+        llm_log.write_text(json.dumps(llm_entry, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def _count_words(self, text: str) -> int:
+        return len([token for token in text.split() if token.strip()])

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -1,0 +1,102 @@
+"""Configuration management for the WordSmith automatikmodus."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class ConfigError(Exception):
+    """Raised when the configuration could not be loaded or validated."""
+
+
+@dataclass
+class LLMParameters:
+    """Deterministic model parameters for reproducible text generation."""
+
+    temperature: float = 0.2
+    top_p: float = 0.9
+    presence_penalty: float = 0.0
+    frequency_penalty: float = 0.3
+    seed: int = 42
+
+    def update(self, values: Dict[str, Any]) -> None:
+        """Update the stored parameters with validated values."""
+
+        for key, value in values.items():
+            if not hasattr(self, key):
+                raise ConfigError(f"Unbekannter LLM-Parameter: {key}")
+            setattr(self, key, float(value))
+
+
+@dataclass
+class Config:
+    """Application configuration loaded by the CLI."""
+
+    output_dir: Path = Path("output")
+    logs_dir: Path = Path("logs")
+    llm_provider: str = "mock-provider"
+    llm: LLMParameters = field(default_factory=LLMParameters)
+    system_prompt: str = (
+        "Du bist ein präziser deutschsprachiger Fachtexter. Du erfindest "
+        "keine Fakten. Bei fehlenden Daten nutzt du Platzhalter in eckigen "
+        "Klammern. Deine Texte sind klar strukturiert, aktiv formuliert, "
+        "redundanzarm und adressatengerecht."
+    )
+    word_count: int = 0
+
+    def adjust_for_word_count(self, word_count: int) -> None:
+        """Store the desired word count and ensure it is sensible."""
+
+        if word_count <= 0:
+            raise ConfigError("`word_count` muss größer als 0 sein.")
+        self.word_count = int(word_count)
+
+    def ensure_directories(self) -> None:
+        """Create output and log directories if they do not exist."""
+
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+
+
+def _update_config_from_dict(config: Config, data: Dict[str, Any]) -> None:
+    """Merge a dictionary of values into the configuration instance."""
+
+    for key, value in data.items():
+        if key in {"output_dir", "logs_dir"}:
+            setattr(config, key, Path(str(value)))
+        elif key == "llm_provider":
+            config.llm_provider = str(value)
+        elif key == "system_prompt":
+            config.system_prompt = str(value)
+        elif key == "llm":
+            if not isinstance(value, dict):
+                raise ConfigError("LLM-Einstellungen müssen ein Objekt sein.")
+            config.llm.update(value)
+        else:
+            raise ConfigError(f"Unbekannter Konfigurationsschlüssel: {key}")
+
+
+def load_config(path: Optional[str | Path] = None) -> Config:
+    """Load configuration data from disk or return defaults."""
+
+    config = Config()
+    if path is None:
+        return config
+
+    config_path = Path(path)
+    if not config_path.exists():
+        raise ConfigError(f"Konfigurationsdatei '{config_path}' wurde nicht gefunden.")
+
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise ConfigError(f"Konfiguration konnte nicht gelesen werden: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ConfigError("Konfigurationsdatei muss ein JSON-Objekt enthalten.")
+
+    _update_config_from_dict(config, data)
+    return config

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -1,0 +1,15 @@
+"""Prompt templates and shared system prompt for WordSmith."""
+
+SYSTEM_PROMPT: str = (
+    "Du bist ein präziser deutschsprachiger Fachtexter. Du erfindest keine "
+    "Fakten. Bei fehlenden Daten nutzt du Platzhalter in eckigen Klammern. "
+    "Deine Texte sind klar strukturiert, aktiv formuliert, redundanzarm "
+    "und adressatengerecht."
+)
+
+
+def set_system_prompt(prompt: str) -> None:
+    """Update the globally shared system prompt."""
+
+    global SYSTEM_PROMPT
+    SYSTEM_PROMPT = prompt


### PR DESCRIPTION
## Summary
- add a full-featured `automatikmodus` CLI command that validates all required inputs, loads configuration, initialises the writer agent and prints the final draft
- introduce a configuration module and prompt helpers so the global system prompt and deterministic parameters are managed centrally
- implement a mock `WriterAgent` that generates the documented artefacts and metadata for the automatic mode
- update the CLI tests to cover success and error paths for the new command

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c904c050ac83259862ac5a3f5123fa