### PR TITLE
Scale context and token limits for word count

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,31 @@
+from wordsmith.config import Config
+
+
+def test_config_initialisation_creates_directories(tmp_path):
+    output_dir = tmp_path / "out"
+    logs_dir = tmp_path / "logs"
+
+    Config(output_dir=output_dir, logs_dir=logs_dir)
+
+    assert output_dir.exists() and output_dir.is_dir()
+    assert logs_dir.exists() and logs_dir.is_dir()
+
+
+def test_adjust_for_word_count_scales_limits_and_sets_determinism():
+    config = Config()
+    config.llm.temperature = 0.7
+    config.llm.top_p = 0.5
+    config.llm.presence_penalty = 1.2
+    config.llm.frequency_penalty = -0.2
+    config.llm.seed = None
+
+    config.adjust_for_word_count(600)
+
+    assert config.word_count == 600
+    assert config.context_length == 2400
+    assert config.token_limit == 960
+    assert config.llm.temperature == 0.2
+    assert config.llm.top_p == 0.9
+    assert config.llm.presence_penalty == 0.0
+    assert config.llm.frequency_penalty == 0.3
+    assert config.llm.seed == 42


### PR DESCRIPTION
## Summary
- add automatic creation of log and output directories when loading configuration values
- scale context length and token limit based on the requested word count and enforce deterministic LLM parameters
- add configuration tests covering directory creation and scaling logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c90778a92c83259dccd2ecb49c3fc1