### PR TITLE
Validate and default extended CLI options

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,14 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
-from cli import main
+from cli import (
+    DEFAULT_AUDIENCE,
+    DEFAULT_CONSTRAINTS,
+    DEFAULT_REGISTER,
+    DEFAULT_TONE,
+    DEFAULT_VARIANT,
+    main,
+)
 from wordsmith import prompts
 
 
@@ -96,3 +103,91 @@ def test_invalid_sources_allowed_value_raises_help():
     with pytest.raises(SystemExit) as exc:
         main(args)
     assert exc.value.code == 2
+
+
+def test_invalid_register_value_causes_error():
+    args = [
+        "automatikmodus",
+        "--title",
+        "Test",
+        "--content",
+        "Inhalt",
+        "--text-type",
+        "Blog",
+        "--word-count",
+        "500",
+        "--register",
+        "freundschaftlich",
+    ]
+
+    with pytest.raises(SystemExit) as exc:
+        main(args)
+
+    assert exc.value.code == 2
+
+
+def test_invalid_variant_value_causes_error():
+    args = [
+        "automatikmodus",
+        "--title",
+        "Test",
+        "--content",
+        "Inhalt",
+        "--text-type",
+        "Blog",
+        "--word-count",
+        "500",
+        "--variant",
+        "de-lu",
+    ]
+
+    with pytest.raises(SystemExit) as exc:
+        main(args)
+
+    assert exc.value.code == 2
+
+
+def test_defaults_applied_for_missing_extended_arguments(tmp_path):
+    output_dir = tmp_path / "output"
+    logs_dir = tmp_path / "logs"
+    args = [
+        "automatikmodus",
+        "--title",
+        "Default-Test",
+        "--content",
+        "Kurzer Hinweis.",
+        "--text-type",
+        "Blogartikel",
+        "--word-count",
+        "400",
+        "--audience",
+        "   ",
+        "--tone",
+        "",
+        "--register",
+        "",
+        "--variant",
+        "  ",
+        "--constraints",
+        "\t",
+        "--output-dir",
+        str(output_dir),
+        "--logs-dir",
+        str(logs_dir),
+    ]
+
+    exit_code = main(args)
+    assert exit_code == 0
+
+    briefing = json.loads((output_dir / "briefing.json").read_text(encoding="utf-8"))
+    assert briefing["audience"] == DEFAULT_AUDIENCE
+    assert briefing["tone"] == DEFAULT_TONE
+    assert briefing["register"] == DEFAULT_REGISTER
+    assert briefing["variant"] == DEFAULT_VARIANT
+    assert briefing["constraints"] == DEFAULT_CONSTRAINTS
+
+    metadata = json.loads((output_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["audience"] == DEFAULT_AUDIENCE
+    assert metadata["register"] == DEFAULT_REGISTER
+    assert metadata["variant"] == DEFAULT_VARIANT
+    assert metadata["keywords"] == []


### PR DESCRIPTION
## Summary
- add dedicated parsers for audience, tone, register, variant, constraints and SEO keywords to normalise values and enforce defaults
- validate register and language variant inputs and deduplicate SEO keyword lists
- cover the new behaviour with CLI tests for invalid inputs and default fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c90a02ed148325b18abbace98edb22