### PR TITLE
Improve error handling, budgeting, and batching

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10,17 +10,20 @@ from typing import List, Optional, Sequence
 from wordsmith import prompts
 from wordsmith.agent import WriterAgent, WriterAgentError
 from wordsmith.config import ConfigError, load_config
+from wordsmith.defaults import (
+    DEFAULT_AUDIENCE,
+    DEFAULT_CONSTRAINTS,
+    DEFAULT_REGISTER,
+    DEFAULT_SOURCES_ALLOWED,
+    DEFAULT_TONE,
+    DEFAULT_VARIANT,
+    REGISTER_ALIASES,
+    VALID_VARIANTS,
+)
 
-DEFAULT_AUDIENCE = "Allgemeine Leserschaft mit Grundkenntnissen"
-DEFAULT_TONE = "sachlich-lebendig"
-DEFAULT_REGISTER = "Sie"
-DEFAULT_VARIANT = "DE-DE"
-DEFAULT_CONSTRAINTS = "Keine zusätzlichen Vorgaben"
-DEFAULT_SOURCES_ALLOWED = False
 DEFAULT_SEO_KEYWORDS: tuple[str, ...] = ()
 
-VALID_REGISTERS = {"du": "Du", "sie": "Sie"}
-VALID_VARIANTS = {"DE-DE", "DE-AT", "DE-CH"}
+VALID_REGISTERS = dict(REGISTER_ALIASES)
 
 
 def _parse_bool(value: str) -> bool:
@@ -55,18 +58,18 @@ def _parse_keywords(value: str) -> List[str]:
 
 def _parse_audience(value: str) -> str:
     value = value.strip()
-    return value or DEFAULT_AUDIENCE
+    return value
 
 
 def _parse_tone(value: str) -> str:
     value = value.strip()
-    return value or DEFAULT_TONE
+    return value
 
 
 def _parse_register(value: str) -> str:
     value = value.strip()
     if not value:
-        return DEFAULT_REGISTER
+        return ""
     normalised = value.lower()
     if normalised not in VALID_REGISTERS:
         valid_values = ", ".join(sorted(VALID_REGISTERS.values()))
@@ -79,7 +82,7 @@ def _parse_register(value: str) -> str:
 def _parse_variant(value: str) -> str:
     value = value.strip()
     if not value:
-        return DEFAULT_VARIANT
+        return ""
     normalised = value.upper()
     if normalised not in VALID_VARIANTS:
         valid_values = ", ".join(sorted(VALID_VARIANTS))
@@ -91,7 +94,7 @@ def _parse_variant(value: str) -> str:
 
 def _parse_constraints(value: str) -> str:
     value = value.strip()
-    return value or DEFAULT_CONSTRAINTS
+    return value
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,130 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from wordsmith.agent import WriterAgent
+from wordsmith.config import Config
+from wordsmith.defaults import (
+    DEFAULT_AUDIENCE,
+    DEFAULT_CONSTRAINTS,
+    DEFAULT_REGISTER,
+    DEFAULT_TONE,
+    DEFAULT_VARIANT,
+)
+
+
+def _build_config(tmp_path: Path, word_count: int) -> Config:
+    config = Config(output_dir=tmp_path / "output", logs_dir=tmp_path / "logs")
+    config.adjust_for_word_count(word_count)
+    return config
+
+
+def test_agent_applies_defaults_and_logs_hint(tmp_path):
+    config = _build_config(tmp_path, 300)
+    agent = WriterAgent(
+        topic="Strategie",
+        word_count=300,
+        steps=[],
+        iterations=0,
+        config=config,
+        content="",
+        text_type="Memo",
+        audience="   ",
+        tone="",
+        register=" ",
+        variant="  ",
+        constraints="",
+        sources_allowed=False,
+    )
+
+    final_text = agent.run()
+    assert "Strategie" in final_text
+
+    assert agent.audience == DEFAULT_AUDIENCE
+    assert agent.tone == DEFAULT_TONE
+    assert agent.register == DEFAULT_REGISTER
+    assert agent.variant == DEFAULT_VARIANT
+    assert agent.constraints == DEFAULT_CONSTRAINTS
+
+    defaults_events = [
+        event
+        for event in agent._run_events
+        if event["step"] == "input_defaults" and "defaults" in event.get("data", {})
+    ]
+    assert defaults_events, "Erwarteter Hinweis zu automatisch gesetzten Werten fehlt."
+    recorded_defaults = set(defaults_events[-1]["data"]["defaults"])
+    assert {"audience", "tone", "register", "variant", "constraints"}.issubset(
+        recorded_defaults
+    )
+
+
+def test_agent_rebalances_word_budget(tmp_path):
+    config = _build_config(tmp_path, 420)
+
+    class ShortWriter(WriterAgent):
+        def _adjust_section_to_budget(self, sentences, budget, briefing, section):  # type: ignore[override]
+            text = super()._adjust_section_to_budget(sentences, budget, briefing, section)
+            words = text.split()
+            if len(words) <= 6:
+                return text
+            keep = max(3, len(words) // 4)
+            truncated = " ".join(words[:keep])
+            return self._ensure_variant(truncated)
+
+    agent = ShortWriter(
+        topic="Budget",  # pragma: no mutate - deterministic input
+        word_count=420,
+        steps=[],
+        iterations=0,
+        config=config,
+        content="Ein kurzer Hinweis auf das Budget.",
+        text_type="Bericht",
+        audience="Führungsteam",
+        tone="klar",
+        register="Sie",
+        variant="DE-DE",
+        constraints="",
+        sources_allowed=False,
+    )
+
+    agent.run()
+
+    rebalance_events = [
+        event for event in agent._run_events if event["step"] == "budget_rebalance"
+    ]
+    assert rebalance_events, "Es wurde kein Re-Balance-Hinweis protokolliert."
+    assert any(event["data"]["redistributed"] > 0 for event in rebalance_events)
+
+
+def test_agent_inserts_recaps_when_batches_trigger(tmp_path):
+    config = _build_config(tmp_path, 640)
+    config.token_limit = 150
+    config.context_length = 300
+
+    content = "Wir haben mehrere Kernbotschaften. " * 3
+
+    agent = WriterAgent(
+        topic="Batch-Test",
+        word_count=640,
+        steps=[],
+        iterations=0,
+        config=config,
+        content=content,
+        text_type="Strategiepapier",
+        audience="Team",
+        tone="inspirierend",
+        register="Du",
+        variant="DE-DE",
+        constraints="",
+        sources_allowed=True,
+    )
+
+    final_text = agent.run()
+
+    assert "Zur Orientierung fasst Batch" in final_text
+    batch_events = [
+        event for event in agent._run_events if event["step"] == "batch_generation"
+    ]
+    assert batch_events, "Batch-Wechsel wurde nicht protokolliert."
+    assert batch_events[0]["data"]["batch_index"] >= 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -271,3 +271,11 @@ def test_defaults_applied_for_missing_extended_arguments(tmp_path):
     )
     assert compliance_report["sources_allowed"] is False
     assert any("block" in entry["sources"] for entry in compliance_report["checks"])
+
+    run_entries = [
+        json.loads(line)
+        for line in (logs_dir / "run.log").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    defaults_event = next(entry for entry in run_entries if entry["step"] == "input_defaults")
+    assert "audience" in defaults_event["data"]["defaults"]

--- a/wordsmith/defaults.py
+++ b/wordsmith/defaults.py
@@ -1,0 +1,19 @@
+"""Shared default values and normalisation helpers for user inputs."""
+
+from __future__ import annotations
+
+DEFAULT_AUDIENCE: str = "Allgemeine Leserschaft mit Grundkenntnissen"
+DEFAULT_TONE: str = "sachlich-lebendig"
+DEFAULT_REGISTER: str = "Sie"
+DEFAULT_VARIANT: str = "DE-DE"
+DEFAULT_CONSTRAINTS: str = "Keine zusätzlichen Vorgaben"
+DEFAULT_SOURCES_ALLOWED: bool = False
+
+# Normalisation map for register values used by CLI and the writer agent.
+REGISTER_ALIASES: dict[str, str] = {
+    "sie": "Sie",
+    "du": "Du",
+}
+
+# Supported language variants.
+VALID_VARIANTS: set[str] = {"DE-DE", "DE-AT", "DE-CH"}


### PR DESCRIPTION
## Summary
- share default value definitions between CLI and agent and surface missing inputs as informative run-log hints
- rebalance section budgets on shortfalls and start new batches with recap sentences when the context limit is hit
- cover the new behaviours with dedicated agent tests and extend the CLI defaults test to assert the hint in the run log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c91ed83dcc8325bcbb6038077cc9ba