### PR TITLE
Set Ollama as default LLM provider

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Sequence
 
 from wordsmith import prompts
 from wordsmith.agent import WriterAgent, WriterAgentError
-from wordsmith.config import ConfigError, load_config
+from wordsmith.config import DEFAULT_LLM_PROVIDER, ConfigError, load_config
 from wordsmith.defaults import (
     DEFAULT_AUDIENCE,
     DEFAULT_CONSTRAINTS,
@@ -135,7 +135,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     automatik_parser.add_argument(
         "--llm-provider",
-        default="mock-provider",
+        default=DEFAULT_LLM_PROVIDER,
         dest="llm_provider",
         help="Bezeichner des verwendeten LLM-Anbieters.",
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ from cli import (
     main,
 )
 from wordsmith import prompts
+from wordsmith.config import DEFAULT_LLM_PROVIDER
 
 
 def test_automatikmodus_requires_arguments():
@@ -259,6 +260,7 @@ def test_defaults_applied_for_missing_extended_arguments(tmp_path):
     assert metadata["register"] == DEFAULT_REGISTER
     assert metadata["variant"] == DEFAULT_VARIANT
     assert metadata["keywords"] == []
+    assert metadata["llm_provider"] == DEFAULT_LLM_PROVIDER
     assert metadata["compliance_checks"]
 
     current_text = (output_dir / "current_text.txt").read_text(encoding="utf-8")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-from wordsmith.config import Config
+from wordsmith.config import DEFAULT_LLM_PROVIDER, Config
 
 
 def test_config_initialisation_creates_directories(tmp_path):
@@ -29,3 +29,9 @@ def test_adjust_for_word_count_scales_limits_and_sets_determinism():
     assert config.llm.presence_penalty == 0.0
     assert config.llm.frequency_penalty == 0.3
     assert config.llm.seed == 42
+
+
+def test_config_uses_ollama_as_default_llm_provider():
+    config = Config()
+
+    assert config.llm_provider == DEFAULT_LLM_PROVIDER

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 
+DEFAULT_LLM_PROVIDER: str = "ollama"
+
+
 class ConfigError(Exception):
     """Raised when the configuration could not be loaded or validated."""
 
@@ -40,7 +43,7 @@ class Config:
 
     output_dir: Path = Path("output")
     logs_dir: Path = Path("logs")
-    llm_provider: str = "mock-provider"
+    llm_provider: str = DEFAULT_LLM_PROVIDER
     llm: LLMParameters = field(default_factory=LLMParameters)
     context_length: int = 4096
     token_limit: int = 1024


### PR DESCRIPTION
## Summary
- set the default LLM provider to the local Ollama setup via a shared constant in the configuration module
- update the CLI argument defaults and automated tests to reflect the new provider value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c95e9abf848325bd9451938e8dcecb