### PR TITLE
Use shared prompts for default system prompt

### DIFF
--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from . import prompts
+
 
 DEFAULT_LLM_PROVIDER: str = "ollama"
 
@@ -47,12 +49,7 @@ class Config:
     llm: LLMParameters = field(default_factory=LLMParameters)
     context_length: int = 4096
     token_limit: int = 1024
-    system_prompt: str = (
-        "Du bist ein präziser deutschsprachiger Fachtexter. Du erfindest "
-        "keine Fakten. Bei fehlenden Daten nutzt du Platzhalter in eckigen "
-        "Klammern. Deine Texte sind klar strukturiert, aktiv formuliert, "
-        "redundanzarm und adressatengerecht."
-    )
+    system_prompt: str = field(default_factory=lambda: prompts.SYSTEM_PROMPT)
     word_count: int = 0
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
## Summary
- update the configuration defaults to source the system prompt from the shared prompts module for easier maintenance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c963b614b0832597a82d14ba309e06