### PR TITLE
Integrate Ollama model selection into CLI

### DIFF
--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -1288,6 +1288,7 @@ class WriterAgent:
             "rubric_passed": rubric_passed,
             "sources_allowed": self.sources_allowed,
             "llm_provider": self.config.llm_provider,
+            "llm_model": self.config.llm_model,
             "system_prompt": prompts.SYSTEM_PROMPT,
             "compliance_checks": self._compliance_audit,
         }
@@ -1310,6 +1311,7 @@ class WriterAgent:
         llm_entry = {
             "stage": "pipeline",
             "provider": self.config.llm_provider,
+            "model": self.config.llm_model,
             "parameters": asdict(self.config.llm),
             "system_prompt": prompts.SYSTEM_PROMPT,
             "topic": self.topic,

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -44,6 +44,7 @@ class Config:
     output_dir: Path = Path("output")
     logs_dir: Path = Path("logs")
     llm_provider: str = DEFAULT_LLM_PROVIDER
+    llm_model: Optional[str] = None
     llm: LLMParameters = field(default_factory=LLMParameters)
     context_length: int = 4096
     token_limit: int = 1024
@@ -96,6 +97,8 @@ def _update_config_from_dict(config: Config, data: Dict[str, Any]) -> None:
             setattr(config, key, Path(str(value)))
         elif key == "llm_provider":
             config.llm_provider = str(value)
+        elif key == "llm_model":
+            config.llm_model = str(value) if value is not None else None
         elif key == "system_prompt":
             config.system_prompt = str(value)
         elif key == "context_length":

--- a/wordsmith/ollama.py
+++ b/wordsmith/ollama.py
@@ -1,0 +1,73 @@
+"""Lightweight HTTP client to interact with a local Ollama instance."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import List, Sequence
+
+
+@dataclass
+class OllamaModel:
+    """Representation of a model entry returned by the Ollama API."""
+
+    name: str
+
+
+class OllamaError(RuntimeError):
+    """Raised when communication with the Ollama API fails."""
+
+
+class OllamaClient:
+    """Small helper around the Ollama HTTP API.
+
+    Only the functionality required by the CLI is implemented: fetching the
+    list of locally available models so the user can choose one for the
+    pipeline run. The client is intentionally minimal and avoids external
+    dependencies so it can run in constrained environments and be mocked
+    easily in tests.
+    """
+
+    def __init__(self, base_url: str = "http://localhost:11434", timeout: float = 5.0) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+    def list_models(self) -> List[OllamaModel]:
+        """Return all locally installed models.
+
+        Raises:
+            OllamaError: If the Ollama daemon is not reachable or the
+                response cannot be parsed.
+        """
+
+        url = f"{self.base_url}/api/tags"
+        request = urllib.request.Request(url, method="GET")
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                payload = response.read()
+        except urllib.error.URLError as exc:  # pragma: no cover - network failure branch
+            raise OllamaError(f"Verbindung zu Ollama fehlgeschlagen: {exc}") from exc
+
+        try:
+            data = json.loads(payload.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise OllamaError("Antwort der Ollama-API konnte nicht gelesen werden.") from exc
+
+        models_data = data.get("models")
+        if not isinstance(models_data, Sequence):
+            raise OllamaError("Unerwartetes Antwortformat der Ollama-API.")
+
+        models: List[OllamaModel] = []
+        for entry in models_data:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            if isinstance(name, str) and name.strip():
+                models.append(OllamaModel(name=name.strip()))
+
+        return models


### PR DESCRIPTION
## Summary
- add a lightweight Ollama client and CLI options to select local models before running the pipeline
- persist the chosen model in the configuration, metadata, and logs so runs capture the provider/model pairing
- extend CLI tests to cover Ollama selection scenarios and default fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c963ea24548325b9c9e5e41956a382