### PR TITLE
Increase Ollama generation timeout

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,36 @@
+import json
+
+from wordsmith import llm
+from wordsmith.config import LLMParameters, OLLAMA_TIMEOUT_SECONDS
+
+
+class _DummyResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return json.dumps({"response": "Antwort"}).encode("utf-8")
+
+
+def test_generate_text_uses_configured_timeout(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["timeout"] = timeout
+        return _DummyResponse()
+
+    monkeypatch.setattr(llm.urllib.request, "urlopen", fake_urlopen)
+
+    result = llm.generate_text(
+        provider="ollama",
+        model="mixtral",
+        prompt="Hallo",
+        system_prompt="System",
+        parameters=LLMParameters(),
+    )
+
+    assert result.text == "Antwort"
+    assert captured["timeout"] == OLLAMA_TIMEOUT_SECONDS

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional
 
 
 DEFAULT_LLM_PROVIDER: str = "ollama"
+OLLAMA_TIMEOUT_SECONDS: int = 3600
 
 
 class ConfigError(Exception):

--- a/wordsmith/llm.py
+++ b/wordsmith/llm.py
@@ -6,7 +6,7 @@ import urllib.request
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
-from .config import LLMParameters
+from .config import LLMParameters, OLLAMA_TIMEOUT_SECONDS
 
 
 @dataclass
@@ -93,7 +93,9 @@ def _generate_with_ollama(
     )
 
     try:
-        with urllib.request.urlopen(request, timeout=30) as response:
+        with urllib.request.urlopen(
+            request, timeout=OLLAMA_TIMEOUT_SECONDS
+        ) as response:
             body = response.read()
     except urllib.error.URLError as exc:  # pragma: no cover - network failure branch
         raise LLMGenerationError(


### PR DESCRIPTION
## Summary
- expose the Ollama HTTP timeout in the configuration and raise it to one hour
- ensure the LLM generation path uses the shared timeout constant
- add a unit test that verifies the configured timeout is honoured when contacting Ollama

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9bc3356188325812ca0a42eb770b1