### PR TITLE
Sanitize Ollama payload before logging

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -34,3 +34,44 @@ def test_generate_text_uses_configured_timeout(monkeypatch):
 
     assert result.text == "Antwort"
     assert captured["timeout"] == OLLAMA_TIMEOUT_SECONDS
+
+
+def test_generate_text_strips_context_from_raw_payload(monkeypatch):
+    payload = {
+        "response": "Antwort",
+        "context": [1, 2, 3],
+        "done": True,
+    }
+
+    class _PayloadResponse:
+        def __init__(self, data: bytes) -> None:
+            self._data = data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return self._data
+
+    response_bytes = json.dumps(payload).encode("utf-8")
+
+    def fake_urlopen(request, timeout):
+        return _PayloadResponse(response_bytes)
+
+    monkeypatch.setattr(llm.urllib.request, "urlopen", fake_urlopen)
+
+    result = llm.generate_text(
+        provider="ollama",
+        model="mixtral",
+        prompt="Hallo",
+        system_prompt="System",
+        parameters=LLMParameters(),
+    )
+
+    assert result.text == "Antwort"
+    assert "context" not in result.raw
+    assert result.raw["context_token_count"] == 3
+    assert result.raw["response"] == "Antwort"

--- a/wordsmith/llm.py
+++ b/wordsmith/llm.py
@@ -33,6 +33,17 @@ def _prepare_options(parameters: LLMParameters) -> Dict[str, Any]:
     return options
 
 
+def _normalise_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of the Ollama payload without bulky token data."""
+
+    cleaned = dict(payload)
+    context = cleaned.get("context")
+    if isinstance(context, list):
+        cleaned["context_token_count"] = len(context)
+        cleaned.pop("context", None)
+    return cleaned
+
+
 def generate_text(
     *,
     provider: str,
@@ -113,4 +124,4 @@ def _generate_with_ollama(
     if not isinstance(text, str) or not text.strip():
         raise LLMGenerationError("Ollama-API lieferte keinen Text zurück.")
 
-    return LLMResult(text=text.strip(), raw=payload)
+    return LLMResult(text=text.strip(), raw=_normalise_payload(payload))


### PR DESCRIPTION
## Summary
- strip the large list of token ids from the Ollama payload before it is logged
- retain a context_token_count field and add coverage to ensure the sanitised payload is returned

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9be9f66a08325a9baee1ce100a364