### PR TITLE
Refactor writer agent to rely on LLM outputs

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,21 +1,17 @@
+from __future__ import annotations
+
+import json
 import sys
-from itertools import cycle
+from collections import deque
 from pathlib import Path
+
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
-from collections import deque
-
 from wordsmith import llm
-from wordsmith.agent import WriterAgent
+from wordsmith.agent import WriterAgent, WriterAgentError
 from wordsmith.config import Config
-from wordsmith.defaults import (
-    DEFAULT_AUDIENCE,
-    DEFAULT_CONSTRAINTS,
-    DEFAULT_REGISTER,
-    DEFAULT_TONE,
-    DEFAULT_VARIANT,
-)
 
 
 def _build_config(tmp_path: Path, word_count: int) -> Config:
@@ -24,250 +20,144 @@ def _build_config(tmp_path: Path, word_count: int) -> Config:
     return config
 
 
-def test_agent_applies_defaults_and_logs_hint(tmp_path):
-    config = _build_config(tmp_path, 300)
-    agent = WriterAgent(
-        topic="Strategie",
-        word_count=300,
-        steps=[],
-        iterations=0,
-        config=config,
-        content="",
-        text_type="Memo",
-        audience="   ",
-        tone="",
-        register=" ",
-        variant="  ",
-        constraints="",
-        sources_allowed=False,
-    )
-
-    final_text = agent.run()
-    assert "Strategie" in final_text
-
-    assert agent.audience == DEFAULT_AUDIENCE
-    assert agent.tone == DEFAULT_TONE
-    assert agent.register == DEFAULT_REGISTER
-    assert agent.variant == DEFAULT_VARIANT
-    assert agent.constraints == DEFAULT_CONSTRAINTS
-
-    defaults_events = [
-        event
-        for event in agent._run_events
-        if event["step"] == "input_defaults" and "defaults" in event.get("data", {})
-    ]
-    assert defaults_events, "Erwarteter Hinweis zu automatisch gesetzten Werten fehlt."
-    recorded_defaults = set(defaults_events[-1]["data"]["defaults"])
-    assert {"audience", "tone", "register", "variant", "constraints"}.issubset(
-        recorded_defaults
-    )
-
-
-def test_agent_rebalances_word_budget(tmp_path):
-    config = _build_config(tmp_path, 420)
-
-    class ShortWriter(WriterAgent):
-        def _adjust_section_to_budget(self, sentences, budget, briefing, section):  # type: ignore[override]
-            text = super()._adjust_section_to_budget(sentences, budget, briefing, section)
-            words = text.split()
-            if len(words) <= 6:
-                return text
-            keep = max(3, len(words) // 4)
-            truncated = " ".join(words[:keep])
-            return self._ensure_variant(truncated)
-
-    agent = ShortWriter(
-        topic="Budget",  # pragma: no mutate - deterministic input
-        word_count=420,
-        steps=[],
-        iterations=0,
-        config=config,
-        content="Ein kurzer Hinweis auf das Budget.",
-        text_type="Bericht",
-        audience="Führungsteam",
-        tone="klar",
-        register="Sie",
-        variant="DE-DE",
-        constraints="",
-        sources_allowed=False,
-    )
-
-    agent.run()
-
-    rebalance_events = [
-        event for event in agent._run_events if event["step"] == "budget_rebalance"
-    ]
-    assert rebalance_events, "Es wurde kein Re-Balance-Hinweis protokolliert."
-    assert any(event["data"]["redistributed"] > 0 for event in rebalance_events)
-
-
-def test_agent_inserts_recaps_when_batches_trigger(tmp_path):
-    config = _build_config(tmp_path, 640)
-    config.token_limit = 150
-    config.context_length = 300
-
-    content = "Wir haben mehrere Kernbotschaften. " * 3
-
-    agent = WriterAgent(
-        topic="Batch-Test",
-        word_count=640,
-        steps=[],
-        iterations=0,
-        config=config,
-        content=content,
-        text_type="Strategiepapier",
-        audience="Team",
-        tone="inspirierend",
-        register="Du",
-        variant="DE-DE",
-        constraints="",
-        sources_allowed=True,
-    )
-
-    final_text = agent.run()
-
-    assert "Zur Orientierung fasst Batch" in final_text
-    batch_events = [
-        event for event in agent._run_events if event["step"] == "batch_generation"
-    ]
-    assert batch_events, "Batch-Wechsel wurde nicht protokolliert."
-    assert batch_events[0]["data"]["batch_index"] >= 2
-
-
-def test_agent_final_text_meets_quality_criteria(tmp_path):
-    config = _build_config(tmp_path, 800)
-    content_lines = [
-        "Stakeholder erwarten belastbare Kennzahlen.",
-        "Teams benötigen klare Prozesse.",
-        "Budgetfragen bleiben offen.",
-        "Pilotteam testet frühe Versionen.",
-        "Risikoteam fordert Transparenz.",
-        "Kunden fragen nach Roadmap.",
-        "Support braucht Einblicke.",
-        "Finanzen wollen Daten.",
-    ]
-    agent = WriterAgent(
-        topic="Innovations-Roadmap",
-        word_count=800,
-        steps=[],
-        iterations=1,
-        config=config,
-        content="\n".join(content_lines),
-        text_type="Strategiepapier",
-        audience="Innovationsabteilung",
-        tone="präzise",
-        register="Sie",
-        variant="DE-DE",
-        constraints="Keine vertraulichen Details",
-        sources_allowed=False,
-        seo_keywords=["Innovationsmanagement"],
-    )
-
-    final_text = agent.run()
-    body, note = agent._extract_compliance_note(final_text)
-
-    # Zielgruppenpassung
-    assert agent.audience in body
-
-    # Faktentreue via Platzhalter und Compliance-Protokoll
-    placeholders = ("[KLÄREN", "[KENNZAHL]", "[QUELLE]", "[DATUM]", "[ZAHL]")
-    assert any(marker in final_text for marker in placeholders)
-    assert any(entry["placeholders_present"] for entry in agent._compliance_audit)
-
-    # Struktur & Stil
-    heading_count = body.count("## ")
-    assert heading_count >= 3
-    assert "## 1." in body and "## 2." in body
-    assert "Nutzen Sie die Impulse" in body
-    assert " du " not in body.lower()
-
-    # Länge innerhalb ±3 %
-    word_count = agent._count_words(body)
-    assert abs(word_count - agent.word_count) / agent.word_count <= 0.03
-
-    # Lesbarkeit & Kohärenz
-    assert "So übersetzt der Abschnitt die Anforderung" in body
-    assert "Der Ausblick bereitet den Abschnitt" in body
-    assert "handlungsfähige Schritte" in body
-    assert "Aufbauend auf" in body
-
-    # Compliance-Hinweis vorhanden
-    assert note.strip().startswith("[COMPLIANCE-")
-
-    # Wiederholungen vermeiden: keine identischen aufeinanderfolgenden Zeilen
-    lines = [line.strip() for line in body.splitlines() if line.strip()]
-    assert all(lines[index] != lines[index + 1] for index in range(len(lines) - 1))
-
-
-def test_enforce_length_trims_excess_words_and_keeps_compliance_note(tmp_path):
+def test_agent_requires_llm_configuration(tmp_path: Path) -> None:
     config = _build_config(tmp_path, 200)
+
     agent = WriterAgent(
-        topic="Längenprüfung",
+        topic="Ohne Modell",
         word_count=200,
         steps=[],
         iterations=0,
         config=config,
         content="Kurze Notiz.",
         text_type="Memo",
-        audience="Controlling",
-        tone="sachlich",
+        audience="Team",
+        tone="klar",
         register="Sie",
         variant="DE-DE",
         constraints="",
         sources_allowed=False,
     )
-    agent._terminology_cache = ["innovation"]
-    agent._term_cycle = cycle(agent._terminology_cache)
 
-    compliance_note = agent._build_compliance_note("draft")
-    long_text = ("Wort " * 400).strip() + "\n\n" + compliance_note
-
-    adjusted = agent._enforce_length(long_text)
-    body, note = agent._extract_compliance_note(adjusted)
-
-    assert agent._count_words(body) <= int(agent.word_count * 1.03)
-    assert note.strip() == compliance_note
+    with pytest.raises(WriterAgentError, match="kein kompatibles LLM-Modell"):
+        agent.run()
 
 
-def test_enforce_length_extends_short_text_to_minimum(tmp_path):
-    config = _build_config(tmp_path, 180)
-    agent = WriterAgent(
-        topic="Expansionstest",
-        word_count=180,
-        steps=[],
-        iterations=0,
-        config=config,
-        content="Ausgangspunkt.",
-        text_type="Notiz",
-        audience="Produktteam",
-        tone="motivierend",
-        register="Du",
-        variant="DE-DE",
-        constraints="",
-        sources_allowed=False,
+def test_agent_generates_outputs_with_llm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _build_config(tmp_path, 300)
+    config.llm_provider = "ollama"
+    config.llm_model = "llama2"
+    config.ollama_base_url = "http://ollama.local"
+
+    briefing_payload = {
+        "goal": "Ausarbeitung",
+        "audience": "Vorstand",
+        "tone": "präzise",
+        "register": "Sie",
+        "variant": "DE-DE",
+        "constraints": "Keine Geheimnisse",
+        "messages": ["Fokus auf Umsetzung"],
+        "key_terms": ["Roadmap"],
+    }
+    idea_text = "- Fokus auf Umsetzung\n- Transparenz sichern"
+    outline_text = (
+        "1. Auftakt (Rolle: Hook, Wortbudget: 80 Wörter) -> Kontext setzen.\n"
+        "2. Strategiepfad (Rolle: Argument, Wortbudget: 140 Wörter) -> Entscheidung stützen."
     )
-    agent._terminology_cache = ["innovation", "strategie", "roadmap"]
-    agent._term_cycle = cycle(agent._terminology_cache)
+    final_text = (
+        "## 1. Auftakt\n"
+        "Dieser Abschnitt beschreibt vertrauliche Aspekte und markiert Bedarf.\n"
+        "## 2. Strategiepfad\n"
+        "Der Plan hält vertraulich Daten und bietet nächste Schritte."
+    )
+    revision_text = (
+        "## Überarbeitet\n"
+        "Die Revision fasst vertrauliche Erkenntnisse zusammen und bleibt konkret."
+    )
 
-    short_text = "Kurzer Satz."
-    expanded = agent._enforce_length(short_text)
-    body, _ = agent._extract_compliance_note(expanded)
+    responses = deque(
+        [
+            llm.LLMResult(text=json.dumps(briefing_payload)),
+            llm.LLMResult(text=idea_text),
+            llm.LLMResult(text=outline_text),
+            llm.LLMResult(text=final_text),
+            llm.LLMResult(text=revision_text),
+        ]
+    )
 
-    assert agent._count_words(body) >= int(agent.word_count * 0.97)
-    assert "Zusätzliche Details" in body
+    def fake_generate_text(**_: object) -> llm.LLMResult:
+        result = responses.popleft()
+        return result
 
+    monkeypatch.setattr("wordsmith.llm.generate_text", fake_generate_text)
 
-def test_revise_draft_removes_duplicates_and_applies_register(tmp_path):
-    config = _build_config(tmp_path, 220)
     agent = WriterAgent(
-        topic="Registertest",
-        word_count=220,
+        topic="Strategische Planung",
+        word_count=300,
         steps=[],
         iterations=1,
         config=config,
-        content="Hinweis.",
-        text_type="Bericht",
-        audience="Innovationsabteilung",
+        content="Wir priorisieren die nächsten Schritte.",
+        text_type="Strategiepapier",
+        audience="Vorstand",
+        tone="präzise",
+        register="Sie",
+        variant="DE-DE",
+        constraints="Keine Geheimnisse",
+        sources_allowed=False,
+        seo_keywords=["Roadmap"],
+    )
+
+    final_output = agent.run()
+
+    idea_output = (config.output_dir / "idea.txt").read_text(encoding="utf-8").strip()
+    outline_output = (config.output_dir / "outline.txt").read_text(encoding="utf-8").strip()
+    current_text = (config.output_dir / "current_text.txt").read_text(encoding="utf-8")
+    metadata = json.loads((config.output_dir / "metadata.json").read_text(encoding="utf-8"))
+    compliance = json.loads((config.output_dir / "compliance.json").read_text(encoding="utf-8"))
+
+    assert "[ENTFERNT: vertrauliche]" in final_output
+    assert "[ENTFERNT: vertrauliche]" in current_text
+    assert idea_output == idea_text
+    assert "Strategiepfad" in outline_output
+    assert metadata["llm_model"] == "llama2"
+    assert metadata["final_word_count"] == agent._count_words(final_output)
+    assert compliance["checks"]
+    stages = {entry["stage"] for entry in compliance["checks"]}
+    assert stages == {"draft", "revision_01"}
+    assert agent._llm_generation and agent._llm_generation["status"] == "success"
+    assert not responses
+
+
+def test_agent_raises_when_llm_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _build_config(tmp_path, 200)
+    config.llm_provider = "ollama"
+    config.llm_model = "mistral"
+
+    responses = deque(
+        [
+            llm.LLMResult(text=json.dumps({"messages": []})),
+            llm.LLMResult(text="- Punkt"),
+            llm.LLMResult(text="1. Abschnitt (Rolle: Hook, Wortbudget: 50 Wörter) -> Test."),
+        ]
+    )
+
+    def failing_generate_text(**kwargs: object) -> llm.LLMResult:
+        if responses:
+            return responses.popleft()
+        raise llm.LLMGenerationError("Ausfall")
+
+    monkeypatch.setattr("wordsmith.llm.generate_text", failing_generate_text)
+
+    agent = WriterAgent(
+        topic="Fehlschlag",
+        word_count=200,
+        steps=[],
+        iterations=0,
+        config=config,
+        content="Notiz",
+        text_type="Memo",
+        audience="Team",
         tone="klar",
         register="Sie",
         variant="DE-DE",
@@ -275,33 +165,21 @@ def test_revise_draft_removes_duplicates_and_applies_register(tmp_path):
         sources_allowed=True,
     )
 
-    draft = (
-        "Das Team handelt schnell. Das Team handelt schnell. du bist informiert. du bist informiert."
-    )
-    revised = agent._revise_draft(draft, 1, {})
-
-    sentences = [
-        sentence.strip().lower()
-        for sentence in agent._split_sentences(revised)
-        if sentence.strip()
-    ]
-    assert sentences.count("das team handelt schnell.") == 1
-    assert sentences.count("sie bist informiert.") == 1
-    assert " du " not in revised.lower()
-    assert revised.strip().endswith(
-        "Revision 1 schärft Klarheit, Flow und Terminologie für Innovationsabteilung."
-    )
+    with pytest.raises(WriterAgentError, match="Finaler Entwurf konnte nicht erstellt"):
+        agent.run()
+    assert agent._llm_generation and agent._llm_generation["status"] == "failed"
 
 
-def test_run_compliance_masks_sensitive_terms_and_adds_placeholders(tmp_path):
-    config = _build_config(tmp_path, 150)
+def test_run_compliance_masks_sensitive_terms(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, 120)
+
     agent = WriterAgent(
         topic="Compliance",
-        word_count=150,
+        word_count=120,
         steps=[],
         iterations=0,
         config=config,
-        content="vertrauliche Daten",  # pragma: no mutate - deterministic input
+        content="",
         text_type="Memo",
         audience="Leitung",
         tone="direkt",
@@ -310,150 +188,12 @@ def test_run_compliance_masks_sensitive_terms_and_adds_placeholders(tmp_path):
         constraints="",
         sources_allowed=False,
     )
-    agent._compliance_audit.clear()
 
-    result = agent._run_compliance(
-        "draft",
-        "Die vertraulichen Angaben fehlen.",
-        ensure_sources=True,
-        annotation_label="pipeline",
-    )
+    result = agent._run_compliance("draft", "Die vertrauliche Information fehlt.")
 
-    assert "[ENTFERNT: vertraulichen]" in result
-    assert "[KLÄREN: Quellenfreigabe ausstehend]" in result
-    assert "[COMPLIANCE-PIPELINE]" in result
-
+    assert "[ENTFERNT: vertrauliche]" in result
     assert agent._compliance_audit
     last_entry = agent._compliance_audit[-1]
     assert last_entry["stage"] == "draft"
-    assert last_entry["placeholders_present"] is True
-    assert "Quellen" in last_entry["sources"]
-
-
-def test_agent_uses_llm_output_when_available(tmp_path, monkeypatch):
-    config = _build_config(tmp_path, 180)
-    config.llm_provider = "ollama"
-    config.llm_model = "llama2"
-    config.ollama_base_url = "http://ollama.local"
-
-    idea_llm_text = (
-        "- Klarer Fokus auf CTA\n"
-        "- Transparenz für das Leitungsteam sichern\n"
-        "Summary: Die Idee verknüpft Strategie und Umsetzung."
-    )
-
-    outline_initial = (
-        "1. Auftakt (Rolle: Hook, Wortbudget: 50 Wörter) -> Aufmerksamkeit wecken.\n"
-        "2. Strategiepfad (Rolle: Argument, Wortbudget: 80 Wörter) -> Handlungsrahmen skizzieren.\n"
-        "3. Abschluss (Rolle: CTA, Wortbudget: 50 Wörter) -> Team aktivieren."
-    )
-
-    outline_improved = (
-        "1. Auftakt (Rolle: Hook, Wortbudget: 60 Wörter) -> Aufmerksamkeit und Kontext schärfen.\n"
-        "2. Strategiepfad (Rolle: Argument, Wortbudget: 70 Wörter) -> Handlungsrahmen priorisieren.\n"
-        "3. Abschluss (Rolle: CTA, Wortbudget: 50 Wörter) -> Team aktivieren und CTA formulieren."
-    )
-
-    final_llm_text = (
-        "## 1. Auftakt (Hook)\n"
-        "Der Auftakt verortet Projekt Aurora für das Leitungsteam und markiert offene Kennzahlen als [KLÄREN: Kennzahl].\n"
-        "## 2. Strategiepfad (Argument)\n"
-        "Der zweite Abschnitt konkretisiert Prozesse und stärkt Vertrauen.\n"
-        "## 3. Abschluss (CTA)\n"
-        "Nutzen Sie die Impulse, um Projekt Aurora im Alltag Ihres Teams zu verankern."
-    )
-
-    responses = deque(
-        [
-            llm.LLMResult(text=idea_llm_text),
-            llm.LLMResult(text=outline_initial),
-            llm.LLMResult(text=outline_improved),
-            llm.LLMResult(text=final_llm_text),
-        ]
-    )
-
-    captured_prompts: list[str] = []
-
-    def fake_generate_text(**kwargs):
-        captured_prompts.append(kwargs["prompt"])
-        return responses.popleft()
-
-    monkeypatch.setattr("wordsmith.llm.generate_text", fake_generate_text)
-
-    agent = WriterAgent(
-        topic="Projekt Aurora",
-        word_count=180,
-        steps=[],
-        iterations=0,
-        config=config,
-        content="Transparenz schaffen und Roadmap konkretisieren.",
-        text_type="Strategiepapier",
-        audience="Leitungsteam",
-        tone="präzise",
-        register="Sie",
-        variant="DE-DE",
-        constraints="Keine vertraulichen Zahlen nennen.",
-        sources_allowed=False,
-    )
-
-    final_text = agent.run()
-
-    assert not responses
-    assert len(captured_prompts) == 4
-    assert "Überarbeite diesen Rohinhalt" in captured_prompts[0]
-    assert "hierarchische Gliederung" in captured_prompts[1]
-    assert "Outline" in captured_prompts[2]
-    assert "Schreibe den finalen" in captured_prompts[3]
-
-    idea_output = (config.output_dir / "idea.txt").read_text(encoding="utf-8")
-    outline_output = (config.output_dir / "outline.txt").read_text(encoding="utf-8")
-
-    assert "Klarer Fokus auf CTA" in idea_output
-    assert "Rolle: Hook" in outline_output
-    assert agent._idea_bullets == [
-        "Klarer Fokus auf CTA",
-        "Transparenz für das Leitungsteam sichern",
-    ]
-    assert any("Budget: 60" in line for line in outline_output.splitlines())
-
-    assert "## 1. Auftakt" in final_text
-    assert "Nutzen Sie die Impulse" in final_text
-    assert "[COMPLIANCE-LLM]" in final_text
-    assert agent._llm_generation and agent._llm_generation["status"] == "success"
-
-    llm_events = [event for event in agent._run_events if event["step"] == "llm_generation"]
-    assert llm_events and llm_events[0]["status"] == "info"
-
-
-def test_agent_falls_back_when_llm_generation_fails(tmp_path, monkeypatch):
-    config = _build_config(tmp_path, 200)
-    config.llm_provider = "ollama"
-    config.llm_model = "mistral"
-
-    def failing_generate_text(**kwargs):
-        raise llm.LLMGenerationError("Ausfall")
-
-    monkeypatch.setattr("wordsmith.llm.generate_text", failing_generate_text)
-
-    agent = WriterAgent(
-        topic="Fallback-Test",
-        word_count=200,
-        steps=[],
-        iterations=0,
-        config=config,
-        content="Team braucht Klarheit über nächste Schritte.",
-        text_type="Memo",
-        audience="Projektteam",
-        tone="klar",
-        register="Du",
-        variant="DE-DE",
-        constraints="", 
-        sources_allowed=True,
-    )
-
-    final_text = agent.run()
-
-    assert "[COMPLIANCE-PIPELINE]" in final_text
-    assert agent._llm_generation and agent._llm_generation["status"] == "failed"
-    llm_events = [event for event in agent._run_events if event["step"] == "llm_generation"]
-    assert llm_events and llm_events[0]["status"] == "warning"
+    assert last_entry["placeholders_present"] is False
+    assert last_entry["sensitive_replacements"] == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import io
 import json
 import sys
+from collections import deque
 from pathlib import Path
 
 import pytest
@@ -16,48 +19,86 @@ from cli import (
     main,
 )
 from wordsmith import llm
-from wordsmith import prompts
-from wordsmith.config import DEFAULT_LLM_PROVIDER
 from wordsmith.ollama import OllamaModel
 
 
-def test_automatikmodus_requires_arguments():
+def test_automatikmodus_requires_arguments() -> None:
     with pytest.raises(SystemExit) as exc:
         main(["automatikmodus"])
     assert exc.value.code == 2
 
 
-def test_automatikmodus_runs_and_creates_outputs(tmp_path, capsys):
+def test_automatikmodus_runs_and_creates_outputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     output_dir = tmp_path / "output"
     logs_dir = tmp_path / "logs"
+
+    monkeypatch.setattr(
+        "wordsmith.ollama.OllamaClient.list_models",
+        lambda self: [OllamaModel(name="llama2")],
+    )
+
+    briefing_payload = {"messages": ["Schritte"], "key_terms": ["Roadmap"]}
+    idea_text = "- Klarer Fokus"
+    outline_text = (
+        "1. Auftakt (Rolle: Hook, Wortbudget: 60 Wörter) -> Kontext schaffen.\n"
+        "2. Umsetzung (Rolle: Argument, Wortbudget: 120 Wörter) -> Handlung empfehlen."
+    )
+    final_text = (
+        "## 1. Auftakt\n"
+        "Der Abschnitt benennt vertrauliche Themen und schafft Klarheit.\n"
+        "## 2. Umsetzung\n"
+        "Der Abschnitt verweist auf vertrauliche Kennzahlen."
+    )
+    revision_text = (
+        "## Überarbeitung\n"
+        "Die Revision blendet vertrauliche Hinweise aus und fokussiert Umsetzung."
+    )
+
+    responses = deque(
+        [
+            llm.LLMResult(text=json.dumps(briefing_payload)),
+            llm.LLMResult(text=idea_text),
+            llm.LLMResult(text=outline_text),
+            llm.LLMResult(text=final_text),
+            llm.LLMResult(text=revision_text),
+        ]
+    )
+
+    def fake_generate_text(**_: object) -> llm.LLMResult:
+        return responses.popleft()
+
+    monkeypatch.setattr("wordsmith.llm.generate_text", fake_generate_text)
+
     args = [
         "automatikmodus",
         "--title",
         "Strategische Roadmap",
         "--content",
-        "Wir brauchen eine klare Roadmap für das nächste Quartal.",
+        "Wir planen die nächsten Schritte.",
         "--text-type",
-        "Blogartikel",
+        "Strategiepapier",
         "--word-count",
-        "600",
+        "400",
         "--iterations",
-        "2",
+        "1",
         "--llm-provider",
-        "provider-x",
+        "ollama",
+        "--ollama-model",
+        "llama2",
         "--audience",
-        "Marketing-Team",
+        "Vorstand",
         "--tone",
-        "faktenbasiert",
+        "präzise",
         "--register",
-        "Du",
+        "Sie",
         "--variant",
-        "DE-AT",
+        "DE-DE",
         "--constraints",
-        "Keine vertraulichen Zahlen nennen.",
+        "Keine Geheimnisse",
         "--sources-allowed",
-        "ja",
+        "nein",
         "--seo-keywords",
-        "roadmap, marketing",
+        "roadmap",
         "--output-dir",
         str(output_dir),
         "--logs-dir",
@@ -68,49 +109,17 @@ def test_automatikmodus_runs_and_creates_outputs(tmp_path, capsys):
     captured = capsys.readouterr()
 
     assert exit_code == 0
-    assert "Strategische Roadmap" in captured.out
-
-    idea_text = (output_dir / "idea.txt").read_text(encoding="utf-8")
-    assert "Überarbeitete Idee" in idea_text
-    assert "-" in idea_text
-    assert "[COMPLIANCE-IDEA]" in idea_text
-    assert "[ENTFERNT:" in idea_text
-
-    outline_text = (output_dir / "outline.txt").read_text(encoding="utf-8")
-    assert "Budget" in outline_text
-    assert "Rolle" in outline_text
-    assert "[COMPLIANCE-OUTLINE]" in outline_text
+    assert "[ENTFERNT: vertrauliche]" in captured.out
 
     current_text = (output_dir / "current_text.txt").read_text(encoding="utf-8")
-    assert "## 1." in current_text
-    assert "Strategische Roadmap" in current_text
-    assert "[KENNZAHL]" in current_text
-    assert "Nutze die Impulse" in current_text
-    assert "[COMPLIANCE-PIPELINE]" in current_text
-    assert "Quellen:\n- [Quelle: Freigabe steht aus]" in current_text
-
-    assert (output_dir / "iteration_00.txt").exists()
-    assert (output_dir / "iteration_01.txt").exists()
-    assert (output_dir / "iteration_02.txt").exists()
-    assert (output_dir / "iteration_03.txt").exists()
-
-    assert (output_dir / "reflection_02.txt").exists()
-    assert (output_dir / "reflection_03.txt").exists()
-
     metadata = json.loads((output_dir / "metadata.json").read_text(encoding="utf-8"))
-    assert metadata["title"] == "Strategische Roadmap"
-    assert metadata["sources_allowed"] is True
-    assert metadata["system_prompt"] == prompts.SYSTEM_PROMPT
-    assert metadata["rubric_passed"] is True
-    assert metadata["llm_model"] is None
-    assert metadata["compliance_checks"]
+    compliance = json.loads((output_dir / "compliance.json").read_text(encoding="utf-8"))
 
-    briefing = json.loads((output_dir / "briefing.json").read_text(encoding="utf-8"))
-    assert "seo_keywords" in briefing
-    assert "roadmap" in briefing["seo_keywords"]
-    assert briefing["key_terms"]
-    assert "compliance" in briefing
-    assert briefing["compliance"]["sources_mode"] == "zugelassen"
+    assert "[ENTFERNT: vertrauliche]" in current_text
+    assert metadata["audience"] == "Vorstand"
+    assert metadata["llm_model"] == "llama2"
+    assert compliance["checks"]
+    assert not responses
 
     run_entries = [
         json.loads(line)
@@ -118,65 +127,54 @@ def test_automatikmodus_runs_and_creates_outputs(tmp_path, capsys):
         if line.strip()
     ]
     assert any(entry["step"] == "briefing" for entry in run_entries)
-    briefing_entry = next(entry for entry in run_entries if entry["step"] == "briefing")
-    assert "briefing.json" in briefing_entry.get("artifacts", [])
-
-    metadata_entry = next(entry for entry in run_entries if entry["step"] == "metadata")
-    assert metadata_entry["data"]["rubric_passed"] is True
-    assert "metadata.json" in metadata_entry.get("artifacts", [])
-
-    revision_steps = {
-        entry["step"] for entry in run_entries if entry["step"].startswith("revision_")
-    }
-    assert revision_steps == {"revision_01", "revision_02"}
-
-    completion_entry = next(entry for entry in run_entries if entry["step"] == "complete")
-    assert completion_entry["status"] == "succeeded"
-    assert completion_entry["data"]["iterations"] == 2
+    assert any(entry["step"] == "revision_01" for entry in run_entries)
 
     llm_entries = [
         json.loads(line)
         for line in (logs_dir / "llm.log").read_text(encoding="utf-8").splitlines()
         if line.strip()
     ]
-    assert llm_entries
-    llm_entry = llm_entries[0]
-    assert llm_entry["stage"] == "pipeline"
-    assert llm_entry["prompts"]["outline"] == prompts.OUTLINE_PROMPT.strip()
-    assert llm_entry["events"][0]["step"] == "start"
-    assert llm_entry.get("model") is None
-
-    compliance_report = json.loads(
-        (output_dir / "compliance.json").read_text(encoding="utf-8")
-    )
-    assert compliance_report["topic"] == "Strategische Roadmap"
-    stages = {entry["stage"] for entry in compliance_report["checks"]}
-    assert {"briefing", "idea", "outline", "draft"}.issubset(stages)
-    assert any(stage.startswith("revision_") for stage in stages)
-    draft_entry = next(
-        entry for entry in compliance_report["checks"] if entry["stage"] == "draft"
-    )
-    assert "Quellenliste" in draft_entry["sources"]
-    assert metadata["compliance_checks"] == compliance_report["checks"]
+    assert llm_entries and llm_entries[0]["llm_generation"]["status"] == "success"
 
 
-def test_iterations_short_option_runs_pipeline(tmp_path):
+def test_cli_reports_llm_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     output_dir = tmp_path / "output"
     logs_dir = tmp_path / "logs"
+
+    monkeypatch.setattr(
+        "wordsmith.ollama.OllamaClient.list_models",
+        lambda self: [OllamaModel(name="llama2")],
+    )
+
+    responses = deque(
+        [
+            llm.LLMResult(text=json.dumps({"messages": []})),
+            llm.LLMResult(text="- Punkt"),
+            llm.LLMResult(text="1. Eintrag (Rolle: Hook, Wortbudget: 50 Wörter) -> Test."),
+        ]
+    )
+
+    def failing_generate_text(**kwargs: object) -> llm.LLMResult:
+        if responses:
+            return responses.popleft()
+        raise llm.LLMGenerationError("Fehler")
+
+    monkeypatch.setattr("wordsmith.llm.generate_text", failing_generate_text)
+
     args = [
         "automatikmodus",
         "--title",
-        "Alias-Test",
+        "Fehler",
         "--content",
-        "Kurzer Hinweis.",
+        "Hinweis",
         "--text-type",
-        "Blogartikel",
+        "Memo",
         "--word-count",
-        "360",
-        "-n",
-        "3",
+        "200",
         "--llm-provider",
-        "provider-x",
+        "ollama",
+        "--ollama-model",
+        "llama2",
         "--output-dir",
         str(output_dir),
         "--logs-dir",
@@ -184,25 +182,13 @@ def test_iterations_short_option_runs_pipeline(tmp_path):
     ]
 
     exit_code = main(args)
+    captured = capsys.readouterr()
 
-    assert exit_code == 0
-    assert (output_dir / "iteration_04.txt").exists()
-    assert (output_dir / "reflection_04.txt").exists()
-
-    run_entries = [
-        json.loads(line)
-        for line in (logs_dir / "run.log").read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
-    completion_entry = next(entry for entry in run_entries if entry["step"] == "complete")
-    assert completion_entry["data"]["iterations"] == 3
-    revision_steps = {
-        entry["step"] for entry in run_entries if entry["step"].startswith("revision_")
-    }
-    assert revision_steps == {"revision_01", "revision_02", "revision_03"}
+    assert exit_code == 1
+    assert "konnte nicht abgeschlossen" in captured.err
 
 
-def test_iterations_argument_rejects_negative_value():
+def test_iterations_argument_rejects_negative_value() -> None:
     args = [
         "automatikmodus",
         "--title",
@@ -223,26 +209,7 @@ def test_iterations_argument_rejects_negative_value():
     assert exc.value.code == 2
 
 
-def test_invalid_sources_allowed_value_raises_help():
-    args = [
-        "automatikmodus",
-        "--title",
-        "Test",
-        "--content",
-        "Inhalt",
-        "--text-type",
-        "Blog",
-        "--word-count",
-        "500",
-        "--sources-allowed",
-        "vielleicht",
-    ]
-    with pytest.raises(SystemExit) as exc:
-        main(args)
-    assert exc.value.code == 2
-
-
-def test_invalid_register_value_causes_error():
+def test_invalid_register_value_causes_error() -> None:
     args = [
         "automatikmodus",
         "--title",
@@ -263,7 +230,7 @@ def test_invalid_register_value_causes_error():
     assert exc.value.code == 2
 
 
-def test_invalid_variant_value_causes_error():
+def test_invalid_variant_value_causes_error() -> None:
     args = [
         "automatikmodus",
         "--title",
@@ -284,18 +251,37 @@ def test_invalid_variant_value_causes_error():
     assert exc.value.code == 2
 
 
-def test_defaults_applied_for_missing_extended_arguments(tmp_path, monkeypatch):
+def test_defaults_applied_for_missing_extended_arguments(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     output_dir = tmp_path / "output"
     logs_dir = tmp_path / "logs"
+
     monkeypatch.setattr(
         "wordsmith.ollama.OllamaClient.list_models",
-        lambda self: [OllamaModel(name="mistral"), OllamaModel(name="llama2")],
+        lambda self: [OllamaModel(name="llama2")],
     )
-    def _fail_generate(**_: object) -> None:
-        raise llm.LLMGenerationError("nicht verfügbar")
 
-    monkeypatch.setattr("wordsmith.llm.generate_text", _fail_generate)
+    responses = deque(
+        [
+            llm.LLMResult(
+                text=json.dumps(
+                    {
+                        "messages": [],
+                        "key_terms": [],
+                    }
+                )
+            ),
+            llm.LLMResult(text="- Hinweis"),
+            llm.LLMResult(text="1. Abschnitt (Rolle: Hook, Wortbudget: 80 Wörter) -> Kontext."),
+            llm.LLMResult(text="## Ergebnis\nDer Text bleibt allgemein."),
+        ]
+    )
+
+    def fake_generate_text(**_: object) -> llm.LLMResult:
+        return responses.popleft()
+
+    monkeypatch.setattr("wordsmith.llm.generate_text", fake_generate_text)
     monkeypatch.setattr("sys.stdin", io.StringIO(""))
+
     args = [
         "automatikmodus",
         "--title",
@@ -305,7 +291,9 @@ def test_defaults_applied_for_missing_extended_arguments(tmp_path, monkeypatch):
         "--text-type",
         "Blogartikel",
         "--word-count",
-        "400",
+        "300",
+        "--iterations",
+        "0",
         "--audience",
         "   ",
         "--tone",
@@ -316,6 +304,10 @@ def test_defaults_applied_for_missing_extended_arguments(tmp_path, monkeypatch):
         "  ",
         "--constraints",
         "\t",
+        "--llm-provider",
+        "ollama",
+        "--ollama-model",
+        "llama2",
         "--output-dir",
         str(output_dir),
         "--logs-dir",
@@ -323,184 +315,18 @@ def test_defaults_applied_for_missing_extended_arguments(tmp_path, monkeypatch):
     ]
 
     exit_code = main(args)
+
     assert exit_code == 0
 
     briefing = json.loads((output_dir / "briefing.json").read_text(encoding="utf-8"))
+    metadata = json.loads((output_dir / "metadata.json").read_text(encoding="utf-8"))
+
     assert briefing["audience"] == DEFAULT_AUDIENCE
     assert briefing["tone"] == DEFAULT_TONE
     assert briefing["register"] == DEFAULT_REGISTER
     assert briefing["variant"] == DEFAULT_VARIANT
     assert briefing["constraints"] == DEFAULT_CONSTRAINTS
 
-    metadata = json.loads((output_dir / "metadata.json").read_text(encoding="utf-8"))
     assert metadata["audience"] == DEFAULT_AUDIENCE
     assert metadata["register"] == DEFAULT_REGISTER
     assert metadata["variant"] == DEFAULT_VARIANT
-    assert metadata["keywords"] == []
-    assert metadata["llm_provider"] == DEFAULT_LLM_PROVIDER
-    assert metadata["llm_model"] == "mistral"
-    assert metadata["compliance_checks"]
-
-    current_text = (output_dir / "current_text.txt").read_text(encoding="utf-8")
-    assert "[COMPLIANCE-PIPELINE]" in current_text
-    assert "[KLÄREN: Quellenfreigabe ausstehend]" in current_text
-    assert "Quellen:" not in current_text
-
-    compliance_report = json.loads(
-        (output_dir / "compliance.json").read_text(encoding="utf-8")
-    )
-    assert compliance_report["sources_allowed"] is False
-    assert any("block" in entry["sources"] for entry in compliance_report["checks"])
-
-    run_entries = [
-        json.loads(line)
-        for line in (logs_dir / "run.log").read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
-    defaults_event = next(entry for entry in run_entries if entry["step"] == "input_defaults")
-    assert "audience" in defaults_event["data"]["defaults"]
-
-
-def test_ollama_model_argument_is_used(tmp_path, monkeypatch, capsys):
-    output_dir = tmp_path / "output"
-    logs_dir = tmp_path / "logs"
-
-    monkeypatch.setattr(
-        "wordsmith.ollama.OllamaClient.list_models",
-        lambda self: [OllamaModel(name="mistral"), OllamaModel(name="llama2")],
-    )
-
-    def _fail_generate(**_: object) -> None:
-        raise llm.LLMGenerationError("nicht verfügbar")
-
-    monkeypatch.setattr("wordsmith.llm.generate_text", _fail_generate)
-
-    args = [
-        "automatikmodus",
-        "--title",
-        "Ollama-Test",
-        "--content",
-        "Kurzer Hinweis.",
-        "--text-type",
-        "Blogartikel",
-        "--word-count",
-        "300",
-        "--llm-provider",
-        "ollama",
-        "--ollama-model",
-        "llama2",
-        "--output-dir",
-        str(output_dir),
-        "--logs-dir",
-        str(logs_dir),
-    ]
-
-    exit_code = main(args)
-    captured = capsys.readouterr()
-
-    assert exit_code == 0
-    assert "Verwende Ollama-Modell: llama2" in captured.out
-
-    metadata = json.loads((output_dir / "metadata.json").read_text(encoding="utf-8"))
-    assert metadata["llm_provider"] == "ollama"
-    assert metadata["llm_model"] == "llama2"
-
-
-def test_cli_uses_llm_text_when_generation_succeeds(tmp_path, monkeypatch, capsys):
-    output_dir = tmp_path / "output"
-    logs_dir = tmp_path / "logs"
-
-    monkeypatch.setattr(
-        "wordsmith.ollama.OllamaClient.list_models",
-        lambda self: [OllamaModel(name="llama2")],
-    )
-
-    llm_calls: list[dict] = []
-    llm_text = (
-        "## 1. Einstieg (Hook)\n"
-        "Der Beitrag rahmt das Thema und markiert offene Kennzahlen als [KLÄREN: Kennzahl].\n"
-        "## 2. Vertiefung (Argument)\n"
-        "Er erläutert die Roadmap, adressiert Prioritäten und zeigt nächste Schritte für das Team.\n"
-        "## 3. Abschluss und CTA (CTA)\n"
-        "Nutzen Sie die Impulse, um die Strategie im Alltag Ihres Teams zu verankern.\n"
-    )
-
-    def _success_generate(**kwargs):
-        llm_calls.append(kwargs)
-        return llm.LLMResult(text=llm_text)
-
-    monkeypatch.setattr("wordsmith.llm.generate_text", _success_generate)
-
-    args = [
-        "automatikmodus",
-        "--title",
-        "LLM-Test",
-        "--content",
-        "Wir wollen echte LLM-Texte nutzen.",
-        "--text-type",
-        "Blogartikel",
-        "--word-count",
-        "360",
-        "--llm-provider",
-        "ollama",
-        "--ollama-model",
-        "llama2",
-        "--output-dir",
-        str(output_dir),
-        "--logs-dir",
-        str(logs_dir),
-    ]
-
-    exit_code = main(args)
-    captured = capsys.readouterr()
-
-    assert exit_code == 0
-    assert "## 1. Einstieg" in captured.out
-    assert llm_calls and llm_calls[0]["model"] == "llama2"
-
-    final_text = (output_dir / "current_text.txt").read_text(encoding="utf-8")
-    assert "[COMPLIANCE-PIPELINE]" in final_text
-    assert "## 1. Einstieg" in final_text
-    assert "Nutzen Sie die Impulse" in final_text
-
-    metadata = json.loads((output_dir / "metadata.json").read_text(encoding="utf-8"))
-    assert metadata["llm_model"] == "llama2"
-
-    llm_entries = [
-        json.loads(line)
-        for line in (logs_dir / "llm.log").read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
-    assert llm_entries
-    assert llm_entries[0]["llm_generation"]["status"] == "success"
-
-
-def test_unknown_ollama_model_returns_error(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        "wordsmith.ollama.OllamaClient.list_models",
-        lambda self: [OllamaModel(name="mistral")],
-    )
-
-    args = [
-        "automatikmodus",
-        "--title",
-        "Fehler",
-        "--content",
-        "Notizen",
-        "--text-type",
-        "Blog",
-        "--word-count",
-        "200",
-        "--llm-provider",
-        "ollama",
-        "--ollama-model",
-        "nicht-vorhanden",
-        "--output-dir",
-        str(tmp_path / "output"),
-        "--logs-dir",
-        str(tmp_path / "logs"),
-    ]
-
-    exit_code = main(args)
-
-    assert exit_code == 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,10 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
 from wordsmith.config import DEFAULT_LLM_PROVIDER, Config
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+
 import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from wordsmith import llm
 from wordsmith.config import LLMParameters, OLLAMA_TIMEOUT_SECONDS

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,5 +1,12 @@
 """Tests for the predefined prompt templates."""
 
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
 from wordsmith import prompts
 
 

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -1,20 +1,25 @@
-"""Implementation of the Automatikmodus writer agent pipeline.
-
-The module emulates the documented steps from ``docs/automatikmodus.md`` in a
-deterministic way so that the CLI can be tested end-to-end without real LLM
-calls.  The agent focuses on structure, artefact creation and rule adherence
-rather than open-ended text generation.
-"""
+"""LLM-first implementation of the Automatikmodus writer agent."""
 
 from __future__ import annotations
 
 import json
 import re
 from dataclasses import asdict, dataclass, field
-from difflib import SequenceMatcher
-from itertools import cycle
 from pathlib import Path
-from typing import Any, Iterable, List, Sequence
+from typing import Any, List, Sequence
+
+from . import llm, prompts
+from .config import Config
+from .defaults import (
+    DEFAULT_AUDIENCE,
+    DEFAULT_CONSTRAINTS,
+    DEFAULT_REGISTER,
+    DEFAULT_TONE,
+    DEFAULT_VARIANT,
+    REGISTER_ALIASES,
+    VALID_VARIANTS,
+)
+from .llm import LLMGenerationError, LLMResult
 
 
 _COMPLIANCE_PLACEHOLDERS: tuple[str, ...] = (
@@ -51,18 +56,6 @@ class OutlineSection:
             f"Wörter) -> {self.deliverable}"
         )
 
-from . import llm, prompts
-from .config import Config
-from .defaults import (
-    DEFAULT_AUDIENCE,
-    DEFAULT_CONSTRAINTS,
-    DEFAULT_REGISTER,
-    DEFAULT_TONE,
-    DEFAULT_VARIANT,
-    REGISTER_ALIASES,
-    VALID_VARIANTS,
-)
-
 
 class WriterAgentError(Exception):
     """Raised when the writer agent cannot complete its work."""
@@ -70,7 +63,7 @@ class WriterAgentError(Exception):
 
 @dataclass
 class WriterAgent:
-    """Deterministic re-implementation of the documented writer pipeline."""
+    """Writer agent that delegates all textual output to the configured LLM."""
 
     topic: str
     word_count: int
@@ -89,14 +82,9 @@ class WriterAgent:
 
     output_dir: Path = field(init=False)
     logs_dir: Path = field(init=False)
-    _terminology_cache: List[str] = field(init=False, default_factory=list)
-    _term_cycle: Iterable[str] = field(init=False, repr=False)
     _idea_bullets: List[str] = field(init=False, default_factory=list)
-    _placeholder_inserted: bool = field(init=False, default=False)
-    _sources_sentence_used: bool = field(init=False, default=False)
-    _keywords_used: set[str] = field(init=False, default_factory=set)
-    _compliance_audit: List[dict] = field(init=False, default_factory=list)
     _run_events: List[dict[str, Any]] = field(init=False, default_factory=list)
+    _compliance_audit: List[dict[str, Any]] = field(init=False, default_factory=list)
     _pending_hints: List[dict[str, Any]] = field(init=False, default_factory=list)
     _llm_generation: dict[str, Any] | None = field(init=False, default=None)
 
@@ -105,13 +93,12 @@ class WriterAgent:
             raise WriterAgentError("`word_count` muss größer als 0 sein.")
         if self.iterations < 0:
             raise WriterAgentError("`iterations` darf nicht negativ sein.")
+
         self.steps = list(self.steps or [])
         self.seo_keywords = [kw.strip() for kw in (self.seo_keywords or []) if kw.strip()]
-        self._pending_hints = []
         self._apply_input_defaults()
         self.output_dir = Path(self.config.output_dir)
         self.logs_dir = Path(self.config.logs_dir)
-        self._term_cycle = cycle([self.topic.lower()])
 
     # ------------------------------------------------------------------
     # Input normalisation and user hints
@@ -237,20 +224,18 @@ class WriterAgent:
                 status="info",
                 data={"defaults": sorted(defaults_used)},
             )
-
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
     def run(self) -> str:
-        """Execute the documented pipeline and return the final text."""
+        """Execute the LLM-driven pipeline and return the final text."""
 
         self.config.ensure_directories()
-        self._placeholder_inserted = False
-        self._sources_sentence_used = False
-        self._keywords_used.clear()
-        self._idea_bullets = []
+        self._idea_bullets.clear()
         self._compliance_audit.clear()
         self._run_events.clear()
+        self._pending_hints.clear()
+        self._llm_generation = None
 
         self._record_run_event(
             "start",
@@ -264,11 +249,11 @@ class WriterAgent:
         )
         self._flush_pending_hints()
 
-        briefing = self._normalize_briefing()
+        briefing = self._generate_briefing()
         self._write_json(self.output_dir / "briefing.json", briefing)
         self._record_run_event(
             "briefing",
-            "Briefing normalisiert",
+            "Briefing mit LLM erzeugt",
             artifacts=[self.output_dir / "briefing.json"],
             data={
                 "messages": len(briefing.get("messages", [])),
@@ -276,22 +261,27 @@ class WriterAgent:
             },
         )
 
-        idea = self._improve_idea(briefing)
-        self._write_text(self.output_dir / "idea.txt", idea)
+        idea_text = self._improve_idea_with_llm()
+        if idea_text is None:
+            raise WriterAgentError("Ideenphase konnte nicht abgeschlossen werden.")
+        self._idea_bullets = self._extract_idea_bullets(idea_text)
+        self._write_text(self.output_dir / "idea.txt", idea_text)
         self._record_run_event(
             "idea",
-            "Idee überarbeitet",
+            "Idee mit LLM überarbeitet",
             artifacts=[self.output_dir / "idea.txt"],
             data={"bullets": len(self._idea_bullets)},
         )
 
-        outline_sections = self._create_outline(briefing)
-        outline_text = self._format_outline(outline_sections)
+        outline_sections = self._create_outline_with_llm(briefing)
+        if not outline_sections:
+            raise WriterAgentError("Outline konnte nicht generiert werden.")
+        outline_text = "\n".join(section.format_line() for section in outline_sections)
         self._write_text(self.output_dir / "outline.txt", outline_text)
         self._write_text(self.output_dir / "iteration_00.txt", outline_text)
         self._record_run_event(
             "outline",
-            "Outline erstellt",
+            "Outline mit LLM erstellt",
             artifacts=[
                 self.output_dir / "outline.txt",
                 self.output_dir / "iteration_00.txt",
@@ -299,83 +289,39 @@ class WriterAgent:
             data={"sections": len(outline_sections)},
         )
 
-        self._llm_generation = None
-        draft_source = "pipeline"
-        llm_draft = self._try_llm_generation(
-            outline_sections, briefing, idea, outline_text
-        )
-        if llm_draft is not None:
-            draft = llm_draft
-            draft_source = "llm"
-        else:
-            draft = self._generate_sections(outline_sections, briefing)
-        draft = self._enforce_length(draft)
-        draft = self._run_compliance(
-            "draft",
-            draft,
-            ensure_sources=True,
-            annotation_label="llm" if draft_source == "llm" else "pipeline",
-        )
+        draft = self._generate_final_draft(briefing, outline_sections, idea_text, outline_text)
+        if draft is None:
+            raise WriterAgentError("Finaler Entwurf konnte nicht erstellt werden.")
+        draft = self._run_compliance("draft", draft, ensure_sources=self.sources_allowed)
         self._write_text(self.output_dir / "current_text.txt", draft)
         self._write_text(self.output_dir / "iteration_01.txt", draft)
-
-        rubric_passed, issues = self._check_text_type(draft, briefing)
-        if issues:
-            draft_body, _ = self._extract_compliance_note(draft)
-            fixed = self._apply_text_type_fix(draft_body, issues, briefing)
-            if not self._similar_enough(draft_body, fixed):
-                fixed = self._blend_with_original(draft_body, fixed)
-            fixed = self._enforce_length(fixed)
-            draft = self._run_compliance(
-                "draft_fix",
-                fixed,
-                ensure_sources=True,
-                annotation_label="pipeline",
-            )
-            self._write_text(self.output_dir / "current_text.txt", draft)
-            self._write_text(self.output_dir / "iteration_01.txt", draft)
-            rubric_passed, _ = self._check_text_type(draft, briefing)
-        else:
-            rubric_passed = True
-
         self.steps.append("draft")
         self._record_run_event(
             "draft",
-            "Initialer Entwurf erstellt",
+            "Initialer Entwurf abgeschlossen",
             artifacts=[
                 self.output_dir / "current_text.txt",
                 self.output_dir / "iteration_01.txt",
             ],
-            data={"rubric_passed": rubric_passed},
-        )
-        self._record_run_event(
-            "text_type_review",
-            "Texttypprüfung abgeschlossen",
-            data={"rubric_passed": rubric_passed},
         )
 
         for iteration in range(1, self.iterations + 1):
-            base_draft, _ = self._extract_compliance_note(draft)
-            revised = self._revise_draft(draft, iteration, briefing)
-            if not self._similar_enough(
-                base_draft, revised, min_jaccard=0.75, min_ratio=0.88
-            ):
-                revised = self._blend_with_original(base_draft, revised)
-            revised = self._enforce_length(revised)
-            draft = self._run_compliance(
+            revised = self._revise_with_llm(draft, iteration, briefing)
+            if revised is None:
+                raise WriterAgentError(
+                    f"Revision {iteration:02d} konnte nicht generiert werden."
+                )
+            revised = self._run_compliance(
                 f"revision_{iteration:02d}",
                 revised,
-                ensure_sources=True,
-                annotation_label="pipeline",
+                ensure_sources=self.sources_allowed,
             )
-            self._write_text(self.output_dir / f"iteration_{iteration + 1:02d}.txt", draft)
+            draft = revised
+            self._write_text(
+                self.output_dir / f"iteration_{iteration + 1:02d}.txt",
+                draft,
+            )
             self._write_text(self.output_dir / "current_text.txt", draft)
-            reflection = self._reflection_notes(iteration)
-            if reflection:
-                self._write_text(
-                    self.output_dir / f"reflection_{iteration + 1:02d}.txt",
-                    reflection,
-                )
             self.steps.append(f"revision_{iteration:02d}")
             self._record_run_event(
                 f"revision_{iteration:02d}",
@@ -386,26 +332,14 @@ class WriterAgent:
                 ],
                 data={"iteration": iteration},
             )
-            if reflection:
-                self._record_run_event(
-                    f"reflection_{iteration + 1:02d}",
-                    f"Reflexion {iteration + 1:02d} gespeichert",
-                    artifacts=[
-                        self.output_dir / f"reflection_{iteration + 1:02d}.txt"
-                    ],
-                    data={"iteration": iteration + 1},
-                )
 
         final_word_count = self._count_words(draft)
-        self._write_metadata(draft, rubric_passed)
+        self._write_metadata(draft)
         self._record_run_event(
             "metadata",
             "Metadaten gespeichert",
             artifacts=[self.output_dir / "metadata.json"],
-            data={
-                "final_word_count": final_word_count,
-                "rubric_passed": rubric_passed,
-            },
+            data={"final_word_count": final_word_count},
         )
         self._write_compliance_report()
         self._record_run_event(
@@ -420,107 +354,53 @@ class WriterAgent:
             status="succeeded",
             data={"iterations": self.iterations, "steps": list(self.steps)},
         )
-        self._write_logs(briefing, outline_sections, rubric_passed)
+        self._write_logs(briefing, outline_sections)
         return draft
 
     # ------------------------------------------------------------------
     # Pipeline steps
     # ------------------------------------------------------------------
-    def _normalize_briefing(self) -> dict:
-        key_terms = self._extract_key_terms()
-        if not key_terms:
-            key_terms = [self.topic.lower()]
-        self._terminology_cache = key_terms
-        self._term_cycle = cycle(self._terminology_cache or [self.topic.lower()])
-
-        messages = [line.strip() for line in self.content.splitlines() if line.strip()]
-        if not messages:
-            messages = ["[KLÄREN: Es wurden keine Notizen geliefert.]"]
-
-        briefing = {
-            "goal": f"{self.text_type} zu '{self.topic}' prägnant entwickeln",
-            "audience": self.audience,
-            "tone": self.tone,
-            "register": self.register,
-            "variant": self.variant,
-            "constraints": self.constraints or "Keine zusätzlichen Vorgaben",
-            "key_terms": key_terms,
-            "messages": messages,
-        }
-        if self.seo_keywords:
-            briefing["seo_keywords"] = list(self.seo_keywords)
-
-        briefing["compliance"] = self._build_briefing_compliance()
-        self._record_compliance(
-            "briefing",
-            placeholders=True,
-            sensitive_hits=0,
-            sources_detail=briefing["compliance"]["sources_mode"],
-            note_present=False,
+    def _generate_briefing(self) -> dict:
+        notes = (self.content or "").strip() or "[KLÄREN: Keine Notizen geliefert.]"
+        seo_text = ", ".join(self.seo_keywords or [])
+        prompt = prompts.BRIEFING_PROMPT.format(
+            title=self.topic,
+            text_type=self.text_type,
+            audience=self.audience,
+            tone=self.tone,
+            register=self.register,
+            variant=self.variant,
+            constraints=self.constraints,
+            seo_keywords=seo_text or "keine",
+            content=notes,
         )
-        self.steps.append("briefing")
+        briefing_text = self._call_llm_stage(
+            stage="briefing_llm",
+            prompt=prompt,
+            success_message="Briefing generiert",
+            failure_message="Briefing-Generierung fehlgeschlagen",
+            data={"phase": "briefing"},
+        )
+        if briefing_text is None:
+            raise WriterAgentError("Briefing konnte nicht generiert werden.")
+        try:
+            briefing = json.loads(briefing_text)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise WriterAgentError(
+                "Briefing-Antwort konnte nicht als JSON interpretiert werden."
+            ) from exc
+        if not isinstance(briefing, dict):
+            raise WriterAgentError("Briefing-Antwort muss ein Objekt sein.")
+        briefing.setdefault("goal", f"{self.text_type} zu '{self.topic}' erstellen")
+        briefing.setdefault("audience", self.audience)
+        briefing.setdefault("tone", self.tone)
+        briefing.setdefault("register", self.register)
+        briefing.setdefault("variant", self.variant)
+        briefing.setdefault("constraints", self.constraints)
+        briefing.setdefault("messages", [])
+        briefing.setdefault("key_terms", [])
+        briefing.setdefault("seo_keywords", list(self.seo_keywords or []))
         return briefing
-
-    def _improve_idea(self, briefing: dict) -> str:
-        if self._should_use_llm():
-            idea_text = self._improve_idea_with_llm()
-            if idea_text:
-                bullets = self._extract_idea_bullets(idea_text)
-                if bullets:
-                    self._idea_bullets = bullets
-                elif not self._idea_bullets:
-                    self._idea_bullets = ["[KLÄREN: Inhaltliches Briefing ergänzen]"]
-                idea_text = self._run_compliance(
-                    "idea", idea_text, annotation_label="idea"
-                )
-                self.steps.append("idea")
-                return idea_text
-
-        raw_sentences = self._split_content_into_sentences(self.content)
-        bullets: List[str] = []
-        for sentence in raw_sentences:
-            cleaned = sentence.strip()
-            if not cleaned:
-                continue
-            if "?" in cleaned or cleaned.endswith("?"):
-                bullets.append(f"[KLÄREN: {cleaned.strip('? ')}]")
-            else:
-                bullets.append(cleaned)
-
-        if not bullets:
-            bullets = ["[KLÄREN: Inhaltliches Briefing ergänzen]"]
-
-        self._idea_bullets = bullets
-        bullet_text = "\n".join(f"- {item}" for item in bullets)
-        summary = (
-            f"Summary: Der Text adressiert {briefing['audience']} und stärkt {self.topic} "
-            f"als {self.text_type}."
-        )
-
-        idea_text = "\n".join(
-            [
-                f"Überarbeitete Idee für '{self.topic}':",
-                bullet_text,
-                "",
-                summary,
-            ]
-        )
-        idea_text = self._run_compliance("idea", idea_text, annotation_label="idea")
-        self.steps.append("idea")
-        return idea_text
-
-    def _create_outline(self, briefing: dict) -> List[OutlineSection]:
-        if self._should_use_llm():
-            sections = self._create_outline_with_llm(briefing)
-            if sections:
-                self.steps.append("outline")
-                return sections
-
-        sections = self._build_outline_sections()
-        sections = self._improve_outline(sections)
-        sections = self._clean_outline(sections)
-        self.steps.append("outline")
-        return sections
 
     def _improve_idea_with_llm(self) -> str | None:
         content = (self.content or "").strip()
@@ -554,9 +434,7 @@ class WriterAgent:
                         bullets.append(cleaned)
         return bullets
 
-    def _create_outline_with_llm(
-        self, briefing: dict
-    ) -> List[OutlineSection] | None:
+    def _create_outline_with_llm(self, briefing: dict) -> List[OutlineSection]:
         prompt = prompts.OUTLINE_PROMPT.format(
             text_type=self.text_type,
             title=self.topic,
@@ -568,37 +446,11 @@ class WriterAgent:
             prompt=prompt,
             success_message="Outline mit LLM erstellt",
             failure_message="LLM-Outline fehlgeschlagen",
-            data={"phase": "initial"},
+            data={"phase": "outline"},
         )
         if not outline_text:
-            return None
-
-        improvement_prompt = (
-            prompts.OUTLINE_IMPROVEMENT_PROMPT.format(word_count=self.word_count)
-            + "\n\nOutline:\n"
-            + outline_text.strip()
-        )
-        improved_text = self._call_llm_stage(
-            stage="outline_llm_improve",
-            prompt=improvement_prompt,
-            success_message="Outline mit LLM verfeinert",
-            failure_message="LLM-Outline-Verbesserung fehlgeschlagen",
-            data={"phase": "improvement"},
-        )
-        outline_source = improved_text or outline_text
-
-        sections = self._parse_outline_sections(outline_source)
-        if not sections:
-            self._record_run_event(
-                "outline_llm_parse",
-                "LLM-Outline konnte nicht interpretiert werden.",
-                status="warning",
-                data={"phase": "parse_failure"},
-            )
-            return None
-
-        sections = self._distribute_outline_budgets(sections)
-        sections = self._clean_outline(sections)
+            return []
+        sections = self._parse_outline_sections(outline_text)
         return sections
 
     def _parse_outline_sections(self, outline_text: str) -> List[OutlineSection]:
@@ -673,239 +525,6 @@ class WriterAgent:
             )
 
         return sections
-
-    def _distribute_outline_budgets(
-        self, sections: List[OutlineSection]
-    ) -> List[OutlineSection]:
-        missing = [section for section in sections if section.budget <= 0]
-        if not missing:
-            return sections
-
-        allocated = sum(section.budget for section in sections if section.budget > 0)
-        remaining = self.word_count - allocated
-        if remaining <= 0:
-            default_budget = max(60, self.word_count // max(1, len(sections)))
-        else:
-            default_budget = max(60, remaining // max(1, len(missing)))
-
-        if default_budget <= 0:
-            default_budget = 60
-
-        for section in sections:
-            if section.budget <= 0:
-                section.budget = default_budget
-        return sections
-
-    def _build_outline_sections(self) -> List[OutlineSection]:
-        total = self.word_count
-        sections: List[OutlineSection]
-        if total < 360:
-            intro = max(60, int(total * 0.25))
-            outro = max(50, int(total * 0.2))
-            body = max(120, total - intro - outro)
-            sections = [
-                OutlineSection(
-                    "1",
-                    "Kontext und Zielbild",
-                    "Hook",
-                    intro,
-                    "Auftrag, Zielgruppe und Relevanz klarziehen.",
-                ),
-                OutlineSection(
-                    "2",
-                    "Kernbotschaften strukturieren",
-                    "Argument",
-                    body,
-                    "Leitthesen, Nutzen und Entscheidungsgrundlagen bündeln.",
-                ),
-                OutlineSection(
-                    "3",
-                    "Fazit und Handlungsimpuls",
-                    "CTA",
-                    outro,
-                    "Schlüsse ziehen und konkrete Aktion anregen.",
-                ),
-            ]
-        else:
-            intro = max(80, int(total * 0.22))
-            outro = max(70, int(total * 0.18))
-            middle = max(180, total - intro - outro)
-            core = max(140, int(middle * 0.55))
-            support = max(100, middle - core)
-            sections = [
-                OutlineSection(
-                    "1",
-                    "Kontext und Zielbild",
-                    "Hook",
-                    intro,
-                    "Ausgangslage, Zielgruppe und Erwartungshaltung verorten.",
-                ),
-                OutlineSection(
-                    "2",
-                    "Strategische Leitplanken",
-                    "Rahmen",
-                    core,
-                    "Erfolgsfaktoren, Prioritäten und Entscheidungskriterien bündeln.",
-                ),
-                OutlineSection(
-                    "3",
-                    "Umsetzung und Taktik",
-                    "Argument",
-                    support,
-                    "Initiativen, Ressourcenbedarf und Meilensteine skizzieren.",
-                ),
-                OutlineSection(
-                    "4",
-                    "Fazit und Handlungsimpuls",
-                    "CTA",
-                    outro,
-                    "Nutzen verdichten und nächsten Schritt aktivieren.",
-                ),
-            ]
-        return sections
-
-    def _improve_outline(self, sections: List[OutlineSection]) -> List[OutlineSection]:
-        improved: List[OutlineSection] = []
-        term_cycle = cycle(self._terminology_cache or [self.topic.lower()])
-        for section in sections:
-            term = next(term_cycle)
-            deliverable = section.deliverable
-            if term and term.lower() not in deliverable.lower():
-                deliverable = f"{deliverable} Terminologie-Fokus: {term}."
-            improved.append(
-                OutlineSection(
-                    number=section.number,
-                    title=section.title,
-                    role=section.role,
-                    budget=section.budget,
-                    deliverable=deliverable,
-                )
-            )
-        return improved
-
-    def _clean_outline(self, sections: List[OutlineSection]) -> List[OutlineSection]:
-        if not sections:
-            return sections
-
-        minimum = 60
-        adjusted: List[OutlineSection] = []
-        total_budget = 0
-        for section in sections:
-            budget = max(minimum, int(section.budget))
-            adjusted.append(
-                OutlineSection(
-                    section.number,
-                    section.title,
-                    section.role,
-                    budget,
-                    section.deliverable,
-                )
-            )
-            total_budget += budget
-
-        difference = self.word_count - total_budget
-        if difference:
-            per_section = difference // len(adjusted)
-            remainder = difference % len(adjusted)
-            balanced: List[OutlineSection] = []
-            for idx, section in enumerate(adjusted):
-                extra = per_section + (1 if idx < remainder else 0)
-                new_budget = max(minimum, section.budget + extra)
-                balanced.append(
-                    OutlineSection(
-                        section.number,
-                        section.title,
-                        section.role,
-                        new_budget,
-                        section.deliverable,
-                    )
-                )
-            adjusted = balanced
-
-        recalculated = sum(section.budget for section in adjusted)
-        if recalculated != self.word_count:
-            delta = self.word_count - recalculated
-            last = adjusted[-1]
-            adjusted[-1] = OutlineSection(
-                last.number,
-                last.title,
-                last.role,
-                max(minimum, last.budget + delta),
-                last.deliverable,
-            )
-
-        return adjusted
-
-    def _format_outline(self, sections: Sequence[OutlineSection]) -> str:
-        outline_text = "\n".join(section.format_line() for section in sections)
-        return self._run_compliance(
-            "outline", outline_text, annotation_label="outline"
-        )
-
-    def _call_llm_stage(
-        self,
-        *,
-        stage: str,
-        prompt: str,
-        success_message: str,
-        failure_message: str,
-        data: dict[str, Any] | None = None,
-    ) -> str | None:
-        try:
-            result = llm.generate_text(
-                provider=self.config.llm_provider,
-                model=self.config.llm_model,
-                prompt=prompt,
-                system_prompt=prompts.SYSTEM_PROMPT,
-                parameters=self.config.llm,
-                base_url=self.config.ollama_base_url,
-            )
-        except LLMGenerationError as exc:
-            event_data = {"provider": self.config.llm_provider, "model": self.config.llm_model}
-            if data:
-                event_data.update(data)
-            event_data["error"] = str(exc)
-            self._record_run_event(
-                stage,
-                f"{failure_message}: {exc}",
-                status="warning",
-                data=event_data,
-            )
-            return None
-
-        text = result.text.strip()
-        if not text:
-            event_data = {"provider": self.config.llm_provider, "model": self.config.llm_model}
-            if data:
-                event_data.update(data)
-            self._record_run_event(
-                stage,
-                f"{failure_message}: leere Antwort",
-                status="warning",
-                data=event_data,
-            )
-            return None
-
-        event_data = {
-            "provider": self.config.llm_provider,
-            "model": self.config.llm_model,
-            "characters": len(text),
-        }
-        if data:
-            event_data.update(data)
-        self._record_run_event(
-            stage,
-            success_message,
-            status="info",
-            data=event_data,
-        )
-        return text
-
-    def _should_use_llm(self) -> bool:
-        provider = (self.config.llm_provider or "").strip().lower()
-        model = (self.config.llm_model or "").strip()
-        return bool(model) and provider == "ollama"
-
     def _build_llm_prompt(
         self,
         briefing: dict,
@@ -914,22 +533,22 @@ class WriterAgent:
         idea_text: str,
         outline_text: str,
     ) -> str:
-        outline_clean = outline_text.strip()
-        if not outline_clean:
-            outline_clean = "\n".join(
-                (
-                    f"{section.number}. {section.title} ({section.role}) – "
-                    f"{section.deliverable} [{section.budget} Wörter]"
-                )
-                for section in sections
+        outline_clean = outline_text.strip() or "\n".join(
+            (
+                f"{section.number}. {section.title} ({section.role}) – "
+                f"{section.deliverable} [{section.budget} Wörter]"
             )
+            for section in sections
+        )
         idea_clean = idea_text.strip()
         if not idea_clean:
             bullets = self._idea_bullets or ["[KLÄREN: Ideenbriefing ergänzen]"]
             idea_clean = "\n".join(f"- {item}" for item in bullets)
 
         seo_text = ", ".join(self.seo_keywords or []) or "keine"
-        variant_hint = f"Verwende Rechtschreibung für {self.variant}" if self.variant else "Nutze Standardsprache"
+        variant_hint = (
+            f"Verwende Rechtschreibung für {self.variant}" if self.variant else "Nutze Standardsprache"
+        )
         sources_mode = "Quellen erlaubt" if self.sources_allowed else "Quellenangaben blockiert"
         constraints = self.constraints or DEFAULT_CONSTRAINTS
 
@@ -948,23 +567,21 @@ class WriterAgent:
             seo_keywords=seo_text,
         )
 
-    def _try_llm_generation(
+    def _generate_final_draft(
         self,
-        sections: Sequence[OutlineSection],
         briefing: dict,
+        sections: Sequence[OutlineSection],
         idea_text: str,
         outline_text: str,
     ) -> str | None:
         if not self._should_use_llm():
-            return None
+            raise WriterAgentError("Für den Automatikmodus muss ein LLM-Modell konfiguriert sein.")
 
-        idea_body, _ = self._extract_compliance_note(idea_text)
-        outline_body, _ = self._extract_compliance_note(outline_text)
         prompt = self._build_llm_prompt(
             briefing,
             sections,
-            idea_text=idea_body or idea_text,
-            outline_text=outline_body or outline_text,
+            idea_text=idea_text,
+            outline_text=outline_text,
         )
 
         try:
@@ -1038,148 +655,25 @@ class WriterAgent:
         )
         return text
 
-    def _generate_sections(self, sections: Sequence[OutlineSection], briefing: dict) -> str:
-        paragraphs: List[str] = []
-        previous_summary = ""
-        mutable_sections = [
-            OutlineSection(section.number, section.title, section.role, section.budget, section.deliverable)
-            for section in sections
-        ]
-        batch_index = 1
-        batch_limit = max(100, int(self.config.token_limit * 0.9))
-        batch_usage = 0
-
-        for index, section in enumerate(mutable_sections):
-            recap_sentence: str | None = None
-            estimated_usage = section.budget
-            if batch_usage and batch_usage + estimated_usage > batch_limit:
-                batch_index += 1
-                recap_sentence = self._build_recap_sentence(previous_summary, batch_index)
-                self._record_run_event(
-                    "batch_generation",
-                    f"Kontextlimit erreicht – Batch {batch_index} gestartet.",
-                    status="info",
-                    data={
-                        "batch_index": batch_index,
-                        "limit": batch_limit,
-                        "trigger_section": section.number,
-                    },
-                )
-                batch_usage = 0
-
-            section_text, summary = self._compose_section(
-                section,
-                index,
-                mutable_sections,
-                briefing,
-                previous_summary,
-                recap_sentence=recap_sentence,
-            )
-            paragraphs.append(section_text)
-            previous_summary = summary
-
-            body = section_text.split("\n", 1)[1] if "\n" in section_text else section_text
-            actual_words = self._count_words(body)
-            batch_usage += actual_words
-
-            shortfall = section.budget - actual_words
-            threshold = max(3, int(section.budget * 0.05))
-            if shortfall >= threshold and index < len(mutable_sections) - 1:
-                redistributed = self._rebalance_future_budgets(mutable_sections, index + 1, shortfall)
-                if redistributed:
-                    self._record_run_event(
-                        "budget_rebalance",
-                        (
-                            f"Wortbudget nach Abschnitt {section.number} um {redistributed} Wörter neu verteilt."
-                        ),
-                        status="info",
-                        data={
-                            "section": section.number,
-                            "planned": section.budget,
-                            "actual": actual_words,
-                            "shortfall": shortfall,
-                            "redistributed": redistributed,
-                        },
-                    )
-
-        return "\n\n".join(paragraphs)
-
-    def _rebalance_future_budgets(
-        self,
-        sections: List[OutlineSection],
-        start_index: int,
-        surplus: int,
-    ) -> int:
-        if start_index >= len(sections) or surplus <= 0:
-            return 0
-
-        remaining = sections[start_index:]
-        total_reference = sum(section.budget for section in remaining)
-        if total_reference <= 0:
-            return 0
-
-        base_shares = [
-            (surplus * section.budget) // total_reference if total_reference else 0
-            for section in remaining
-        ]
-        distributed = sum(base_shares)
-        remainder = surplus - distributed
-
-        if remainder > 0:
-            order = sorted(
-                range(len(remaining)),
-                key=lambda idx: remaining[idx].budget,
-                reverse=True,
-            )
-            for position in order:
-                if remainder <= 0:
-                    break
-                base_shares[position] += 1
-                remainder -= 1
-
-        distributed = sum(base_shares)
-        for offset, share in enumerate(base_shares):
-            if share <= 0:
-                continue
-            idx = start_index + offset
-            section = sections[idx]
-            sections[idx] = OutlineSection(
-                section.number,
-                section.title,
-                section.role,
-                section.budget + share,
-                section.deliverable,
-            )
-        return distributed
-
-    def _build_recap_sentence(self, summary: str, batch_index: int) -> str:
-        cleaned = summary.strip().rstrip(". ") if summary.strip() else (
-            "die bisherige Passage die Ausgangslage skizziert hat"
+    def _revise_with_llm(self, text: str, iteration: int, briefing: dict) -> str | None:
+        revision_prompt = (
+            prompts.REVISION_PROMPT.strip()
+            + "\n\nBriefing:\n"
+            + json.dumps(briefing, ensure_ascii=False, indent=2)
+            + "\n\nAktueller Text:\n"
+            + text.strip()
         )
-        previous_batch = max(1, batch_index - 1)
-        return (
-            f"Zur Orientierung fasst Batch {previous_batch} zusammen: {cleaned}. "
-            "Der neue Abschnitt knüpft daran an und vertieft den Gedanken."
+        return self._call_llm_stage(
+            stage=f"revision_{iteration:02d}_llm",
+            prompt=revision_prompt,
+            success_message=f"Revision {iteration:02d} generiert",
+            failure_message=f"Revision {iteration:02d} fehlgeschlagen",
+            data={"iteration": iteration},
         )
 
     # ------------------------------------------------------------------
     # Compliance helpers
     # ------------------------------------------------------------------
-    def _build_briefing_compliance(self) -> dict:
-        sources_mode = "zugelassen" if self.sources_allowed else "gesperrt"
-        return {
-            "policy": "Keine erfundenen Fakten.",
-            "placeholders": [
-                "[KLÄREN: ...]",
-                "[KENNZAHL]",
-                "[QUELLE]",
-                "[DATUM]",
-                "[ZAHL]",
-            ],
-            "sources_mode": sources_mode,
-            "sensitive_handling": "Sensible Inhalte als [ENTFERNT: sensibler inhalt] kennzeichnen.",
-        }
-
     def _extract_compliance_note(self, text: str) -> tuple[str, str]:
         stripped = text.strip()
         if "[COMPLIANCE-" not in stripped:
@@ -1191,25 +685,6 @@ class WriterAgent:
 
     def _contains_placeholder(self, text: str) -> bool:
         return any(marker in text for marker in _COMPLIANCE_PLACEHOLDERS)
-
-    def _add_placeholder(self, text: str, stage: str) -> str:
-        placeholder = "[KLÄREN: Daten werden nachgereicht.]"
-        if not text:
-            return placeholder
-        if stage == "idea" and "\n" in text:
-            return text.rstrip() + f"\n- {placeholder}"
-        if "\n" in text:
-            return text.rstrip() + "\n\n" + placeholder
-        return text.rstrip() + " " + placeholder
-
-    def _build_compliance_note(self, label: str) -> str:
-        sources_state = "erlaubt" if self.sources_allowed else "gesperrt"
-        return (
-            f"[COMPLIANCE-{label.upper()}] Keine erfundenen Fakten; offene Angaben bleiben "
-            "durch Platzhalter wie [KLÄREN: ...] und [KENNZAHL] markiert; "
-            "sensible Inhalte werden als [ENTFERNT: sensibler inhalt] gekennzeichnet; "
-            f"Quellenmodus: {sources_state}."
-        )
 
     def _mask_sensitive_content(self, text: str) -> tuple[str, int]:
         replacements = 0
@@ -1225,36 +700,6 @@ class WriterAgent:
             updated = pattern.sub(_replace, updated)
         return updated, replacements
 
-    def _ensure_sources_policy(self, text: str) -> tuple[str, str]:
-        if self.sources_allowed:
-            cleaned = re.sub(
-                r"\s*Quellen:\s*(?:-?\s*\[Quelle:[^\]]+\][^\n]*)?(?:\n-?\s*\[Quelle:[^\]]+\][^\n]*)*",
-                "",
-                text,
-                flags=re.IGNORECASE,
-            )
-            cleaned = cleaned.strip()
-            if cleaned:
-                cleaned += "\n\n"
-            cleaned += "Quellen:\n- [Quelle: Freigabe steht aus]"
-            return cleaned, "Quellenliste formatiert"
-
-        placeholder = "[KLÄREN: Quellenfreigabe ausstehend]"
-        lines = text.splitlines()
-        filtered_lines = [
-            line
-            for line in lines
-            if not line.strip().startswith("Quellen:")
-            and not line.strip().startswith("- [Quelle:")
-        ]
-        cleaned = "\n".join(filtered_lines).strip()
-        if placeholder not in cleaned:
-            cleaned = (cleaned.rstrip() + "\n\n" + placeholder) if cleaned else placeholder
-            detail = "Quellen blockiert"
-        else:
-            detail = "Quellenblock bestätigt"
-        return cleaned, detail
-
     def _run_compliance(
         self,
         stage: str,
@@ -1263,23 +708,15 @@ class WriterAgent:
         ensure_sources: bool = False,
         annotation_label: str | None = None,
     ) -> str:
-        body, _ = self._extract_compliance_note(text)
-        updated, sensitive_hits = self._mask_sensitive_content(body)
-        if not self._contains_placeholder(updated):
-            updated = self._add_placeholder(updated, stage)
-        sources_detail = "nicht erforderlich"
-        if ensure_sources:
-            updated, sources_detail = self._ensure_sources_policy(updated)
-        note = self._build_compliance_note(annotation_label or stage)
-        if note not in updated:
-            updated = updated.rstrip() + "\n\n" + note
+        updated, sensitive_hits = self._mask_sensitive_content(text)
         placeholders_present = self._contains_placeholder(updated)
+        sources_detail = "zugelassen" if ensure_sources else "gesperrt"
         self._record_compliance(
             stage,
             placeholders=placeholders_present,
             sensitive_hits=sensitive_hits,
             sources_detail=sources_detail,
-            note_present=True,
+            note_present=False,
         )
         return updated
 
@@ -1309,367 +746,6 @@ class WriterAgent:
             "checks": self._compliance_audit,
         }
         self._write_json(self.output_dir / "compliance.json", report)
-
-    def _compose_section(
-        self,
-        section: OutlineSection,
-        index: int,
-        sections: Sequence[OutlineSection],
-        briefing: dict,
-        previous_summary: str,
-        *,
-        recap_sentence: str | None = None,
-    ) -> tuple[str, str]:
-        heading = f"## {section.number}. {section.title} ({section.role})"
-        sentences: List[str] = []
-        key_terms = self._take_terms(2)
-        messages = briefing["messages"]
-        message = messages[index % len(messages)] if messages else self.topic
-
-        if index == 0:
-            sentences.append(
-                f"Dieser {self.text_type.lower()} positioniert '{self.topic}' für {self.audience} und erklärt, "
-                f"warum {briefing['goal']} jetzt wichtig ist."
-            )
-        else:
-            reference = previous_summary or sections[index - 1].title.lower()
-            sentences.append(
-                f"Aufbauend auf {reference} vertieft der Abschnitt die Perspektive auf {self.topic}."
-            )
-
-        if recap_sentence:
-            sentences.append(recap_sentence)
-
-        if key_terms:
-            focus_terms = ", ".join(key_terms)
-            sentences.append(
-                f"{section.deliverable} Begriffe wie {focus_terms} dienen als Terminologie-Anker."
-            )
-        else:
-            sentences.append(f"{section.deliverable} Dabei bleibt der Fokus klar auf {self.topic}.")
-
-        if self._idea_bullets:
-            bullet = self._idea_bullets[index % len(self._idea_bullets)].strip()
-            sentences.append(f"Die ausgearbeitete Idee betont: {bullet}.")
-
-        if not self._placeholder_inserted:
-            sentences.append(
-                "Kennzahlen ohne Freigabe markieren wir als [KENNZAHL], bis die verantwortlichen Stellen sie liefern."
-            )
-            self._placeholder_inserted = True
-
-        if self.seo_keywords:
-            self._inject_keyword(sentences)
-
-        if not self.sources_allowed and not self._sources_sentence_used:
-            sentences.append("Quellenangaben werden nach Freigabe ergänzt [KLÄREN: Quellenfreigabe].")
-            self._sources_sentence_used = True
-
-        sentences.append(
-            f"So übersetzt der Abschnitt die Anforderung '{message}' in handlungsfähige Schritte."
-        )
-
-        if index < len(sections) - 1:
-            next_title = sections[index + 1].title
-            sentences.append(f"Der Ausblick bereitet den Abschnitt \"{next_title}\" vor.")
-        else:
-            sentences.append(self._cta_sentence())
-
-        text = self._adjust_section_to_budget(sentences, section.budget, briefing, section)
-        summary = self._section_summary(section, text)
-        return heading + "\n" + text, summary
-
-    def _cta_sentence(self) -> str:
-        if self.register.lower() == "du":
-            return (
-                f"Nutze die Impulse, um {self.topic.lower()} im Alltag deines Teams zu verankern."
-            )
-        return (
-            f"Nutzen Sie die Impulse, um {self.topic.lower()} im Alltag Ihres Teams zu verankern."
-        )
-
-    def _adjust_section_to_budget(
-        self,
-        sentences: List[str],
-        budget: int,
-        briefing: dict,
-        section: OutlineSection,
-    ) -> str:
-        lower = max(1, int(budget * 0.85))
-        upper = max(lower, int(budget * 1.05))
-        text = " ".join(sentences)
-        words = self._count_words(text)
-
-        while words > upper and len(sentences) > 1:
-            sentences.pop()
-            text = " ".join(sentences)
-            words = self._count_words(text)
-
-        if words > upper:
-            trimmed_words = text.split()[:upper]
-            text = " ".join(trimmed_words)
-            words = len(trimmed_words)
-
-        while words < lower:
-            sentences.append(self._expansion_sentence(briefing, section))
-            text = " ".join(sentences)
-            words = self._count_words(text)
-
-        return self._ensure_variant(text)
-
-    def _expansion_sentence(self, briefing: dict, section: OutlineSection) -> str:
-        term = self._take_terms(1)
-        message = briefing["messages"][0] if briefing["messages"] else self.topic
-        keyword = term[0] if term else self.topic.lower()
-        return (
-            f"Der Abschnitt verknüpft {message} mit dem Schlüsselbegriff {keyword} und hält den Fokus auf {section.title}."
-        )
-
-    def _section_summary(self, section: OutlineSection, text: str) -> str:
-        first_sentence = text.split(".")[0].strip()
-        if first_sentence:
-            return first_sentence
-        return section.title.lower()
-
-    def _take_terms(self, count: int) -> List[str]:
-        if not self._terminology_cache:
-            return []
-        terms: List[str] = []
-        for _ in range(count):
-            term = next(self._term_cycle)
-            terms.append(term)
-        return terms
-
-    def _inject_keyword(self, sentences: List[str]) -> None:
-        for keyword in self.seo_keywords or []:
-            lowered = keyword.lower()
-            if lowered in self._keywords_used:
-                continue
-            sentences.append(
-                f"Das Stichwort '{keyword}' stärkt die SEO-Ausrichtung ohne den Lesefluss zu stören."
-            )
-            self._keywords_used.add(lowered)
-            break
-
-    # ------------------------------------------------------------------
-    # Text generation utilities
-    # ------------------------------------------------------------------
-    def _split_content_into_sentences(self, text: str) -> List[str]:
-        sentences: List[str] = []
-        for raw in text.replace("\n", " ").split("."):
-            cleaned = raw.strip()
-            if cleaned:
-                sentences.append(cleaned)
-        return sentences
-
-    def _extract_key_terms(self) -> List[str]:
-        terms = set()
-        for token in self.content.replace("\n", " ").split():
-            token = token.strip().strip(",.;:!?()[]{}" "\"'").lower()
-            if len(token) > 4:
-                terms.add(token)
-        topic_terms = [piece.strip().lower() for piece in self.topic.split() if len(piece) > 4]
-        terms.update(topic_terms)
-        return sorted(terms)
-
-    def _ensure_variant(self, text: str) -> str:
-        variant = self.variant.upper()
-        if variant in {"DE-AT", "DE-CH"}:
-            return text.replace("ß", "ss")
-        return text
-
-    def _count_words(self, text: str) -> int:
-        return len([token for token in text.split() if token.strip()])
-
-    def _enforce_length(self, text: str) -> str:
-        body, note = self._extract_compliance_note(text)
-        base_text = (body if body else text).strip()
-        sentinel = "<<NEWLINE>>"
-
-        def to_tokens(value: str) -> List[str]:
-            return [token for token in value.replace("\n", f" {sentinel} ").split() if token]
-
-        def from_tokens(tokens: List[str]) -> str:
-            lines: List[str] = []
-            current: List[str] = []
-            for token in tokens:
-                if token == sentinel:
-                    lines.append(" ".join(current).strip())
-                    current = []
-                else:
-                    current.append(token)
-            lines.append(" ".join(current).strip())
-            return "\n".join(lines).strip()
-
-        tokens = to_tokens(base_text)
-        word_tokens = [token for token in tokens if token != sentinel]
-        if not word_tokens:
-            result = base_text
-            if note and result:
-                return result + "\n\n" + note
-            if note:
-                return note
-            return base_text
-        min_words = int(self.word_count * 0.97)
-        max_words = int(self.word_count * 1.03)
-        if len(word_tokens) > max_words:
-            trimmed: List[str] = []
-            kept = 0
-            for token in tokens:
-                if token == sentinel:
-                    trimmed.append(token)
-                    continue
-                if kept >= max_words:
-                    break
-                trimmed.append(token)
-                kept += 1
-            tokens = trimmed
-        elif len(word_tokens) < min_words:
-            adjusted_text = base_text
-            filler_terms = self._take_terms(3)
-            if filler_terms:
-                addition = f"Zusätzliche Details zu {', '.join(filler_terms)} verdeutlichen den Nutzen."
-            else:
-                addition = f"Zusätzliche Details verdeutlichen den Nutzen von {self.topic}."
-            while len(word_tokens) < min_words:
-                adjusted_text = (adjusted_text + " " + addition).strip()
-                tokens = to_tokens(adjusted_text)
-                word_tokens = [token for token in tokens if token != sentinel]
-        adjusted = from_tokens(tokens)
-        adjusted = self._ensure_variant(adjusted.strip())
-        if note:
-            combined = adjusted.strip()
-            if combined:
-                return combined + "\n\n" + note
-            return note
-        return adjusted
-
-    # ------------------------------------------------------------------
-    # Quality checks and revisions
-    # ------------------------------------------------------------------
-    def _check_text_type(self, text: str, briefing: dict) -> tuple[bool, List[str]]:
-        issues: List[str] = []
-        lowered = text.lower()
-        if "##" not in text:
-            issues.append("Zwischenüberschriften fehlen.")
-        if "fazit" not in lowered and "abschluss" not in lowered:
-            issues.append("Abschluss fehlt.")
-        if self.register == "Sie" and " du " in lowered:
-            issues.append("Register 'Sie' verletzt.")
-        if self.register == "Du" and " Sie " in text:
-            issues.append("Register 'Du' verletzt.")
-        for keyword in self.seo_keywords or []:
-            if keyword.lower() not in lowered:
-                issues.append(f"SEO-Keyword '{keyword}' fehlt.")
-        if self.register == "Sie" and "Nutzen Sie" not in text:
-            issues.append("CTA in Sie-Ansprache fehlt.")
-        if self.register.lower() == "du" and "Nutze" not in text:
-            issues.append("CTA in Du-Ansprache fehlt.")
-        return (not issues), issues
-
-    def _apply_text_type_fix(self, text: str, issues: List[str], briefing: dict) -> str:
-        fixed = text
-        for issue in issues:
-            if "SEO-Keyword" in issue:
-                keyword = issue.split("'")[1]
-                fixed += f"\n\n{keyword} unterstreicht den thematischen Fokus."  # add gently
-                self._keywords_used.add(keyword.lower())
-            elif "Zwischenüberschriften" in issue:
-                fixed = self._ensure_headings(fixed)
-            elif "CTA" in issue:
-                fixed = fixed.strip() + "\n\n" + self._cta_sentence()
-            elif "Register" in issue:
-                fixed = self._apply_register(fixed)
-            elif "Abschluss" in issue:
-                fixed = fixed.strip() + "\n\n" + "Ein kompaktes Fazit bündelt den Nutzen." \
-                    + f" {self._cta_sentence()}"
-        if not self._similar_enough(text, fixed):
-            fixed = self._blend_with_original(text, fixed)
-        return self._ensure_variant(fixed)
-
-    def _ensure_headings(self, text: str) -> str:
-        lines = text.splitlines()
-        enriched: List[str] = []
-        for line in lines:
-            stripped = line.strip()
-            if stripped and not stripped.startswith("#") and stripped == stripped.upper():
-                enriched.append(f"## {stripped.title()}")
-            else:
-                enriched.append(line)
-        if all(not line.strip().startswith("##") for line in enriched):
-            enriched.insert(0, "## Überblick")
-        return "\n".join(enriched)
-
-    def _similar_enough(
-        self,
-        original: str,
-        revised: str,
-        *,
-        min_jaccard: float = 0.8,
-        min_ratio: float = 0.9,
-    ) -> bool:
-        original_tokens = {token.lower() for token in original.split() if token.strip()}
-        revised_tokens = {token.lower() for token in revised.split() if token.strip()}
-        if not original_tokens or not revised_tokens:
-            return True
-        intersection = len(original_tokens & revised_tokens)
-        jaccard = intersection / max(len(original_tokens), 1)
-        ratio = SequenceMatcher(None, original, revised).ratio()
-        return jaccard >= min_jaccard and ratio >= min_ratio
-
-    def _blend_with_original(self, original: str, revised: str) -> str:
-        base_sentences = self._split_sentences(original)
-        new_sentences = self._split_sentences(revised)
-        combined = base_sentences[:]
-        for sentence in new_sentences:
-            if sentence and sentence not in combined:
-                combined.append(sentence)
-        blended = " ".join(combined)
-        return self._ensure_variant(blended)
-
-    def _split_sentences(self, text: str) -> List[str]:
-        sentences: List[str] = []
-        for raw in text.replace("\n", " ").split("."):
-            cleaned = raw.strip()
-            if cleaned:
-                sentences.append(cleaned + ".")
-        return sentences
-
-    def _apply_register(self, text: str) -> str:
-        if self.register == "Sie":
-            return text.replace(" du ", " Sie ")
-        return text.replace(" Sie ", " du ")
-
-    def _revise_draft(self, text: str, iteration: int, briefing: dict) -> str:
-        body, _ = self._extract_compliance_note(text)
-        sentences = self._split_sentences(body)
-        unique_sentences: List[str] = []
-        seen = set()
-        for sentence in sentences:
-            lowered = sentence.lower()
-            if lowered in seen:
-                continue
-            seen.add(lowered)
-            unique_sentences.append(sentence)
-        revision_note = (
-            f"Revision {iteration} schärft Klarheit, Flow und Terminologie für {self.audience}."
-        )
-        revised = " ".join(unique_sentences) + " " + revision_note
-        revised = self._apply_register(revised)
-        return self._ensure_variant(revised)
-
-    def _reflection_notes(self, iteration: int) -> str:
-        points = [
-            f"Tonfall {self.tone} an Beispielen konkretisieren.",
-            "Praxisbeispiel ergänzen, sobald Daten vorliegen [KLÄREN: Beispiel].",
-            f"CTA stärker auf {self.audience} zuschneiden.",
-        ]
-        header = f"Reflexion nach Revision {iteration}:"
-        lines = [header]
-        for idx, point in enumerate(points, start=1):
-            lines.append(f"{idx}. {point}")
-        return "\n".join(lines)
-
     # ------------------------------------------------------------------
     # Output helpers
     # ------------------------------------------------------------------
@@ -1679,7 +755,7 @@ class WriterAgent:
     def _write_text(self, path: Path, text: str) -> None:
         path.write_text(text.strip() + "\n", encoding="utf-8")
 
-    def _write_metadata(self, text: str, rubric_passed: bool) -> None:
+    def _write_metadata(self, text: str) -> None:
         metadata = {
             "title": self.topic,
             "audience": self.audience,
@@ -1688,7 +764,7 @@ class WriterAgent:
             "variant": self.variant,
             "keywords": list(self.seo_keywords or []),
             "final_word_count": self._count_words(text),
-            "rubric_passed": rubric_passed,
+            "rubric_passed": None,
             "sources_allowed": self.sources_allowed,
             "llm_provider": self.config.llm_provider,
             "llm_model": self.config.llm_model,
@@ -1701,7 +777,6 @@ class WriterAgent:
         self,
         briefing: dict,
         outline_sections: Sequence[OutlineSection],
-        rubric_passed: bool,
     ) -> None:
         run_log = self.logs_dir / "run.log"
         run_entries = [dict(entry) for entry in self._run_events]
@@ -1721,19 +796,14 @@ class WriterAgent:
             "word_count": self.word_count,
             "audience": self.audience,
             "text_type": self.text_type,
-            "messages": briefing["messages"],
+            "messages": briefing.get("messages", []),
             "outline": [asdict(section) for section in outline_sections],
-            "rubric_passed": rubric_passed,
             "prompts": {
                 "briefing": prompts.BRIEFING_PROMPT.strip(),
                 "idea": prompts.IDEA_IMPROVEMENT_PROMPT.strip(),
                 "outline": prompts.OUTLINE_PROMPT.strip(),
-                "outline_improvement": prompts.OUTLINE_IMPROVEMENT_PROMPT.strip(),
-                "section": prompts.SECTION_PROMPT.strip(),
-                "text_type_check": prompts.TEXT_TYPE_CHECK_PROMPT.strip(),
-                "text_type_fix": prompts.TEXT_TYPE_FIX_PROMPT.strip(),
+                "final": prompts.FINAL_DRAFT_PROMPT.strip(),
                 "revision": prompts.REVISION_PROMPT.strip(),
-                "reflection": prompts.REFLECTION_PROMPT.strip(),
             },
             "events": run_entries,
             "llm_generation": self._llm_generation,
@@ -1768,4 +838,72 @@ class WriterAgent:
                 return str(path.relative_to(self.logs_dir))
             except ValueError:
                 return str(path)
-from .llm import LLMGenerationError, LLMResult
+
+    def _should_use_llm(self) -> bool:
+        provider = (self.config.llm_provider or "").strip().lower()
+        model = (self.config.llm_model or "").strip()
+        return bool(model) and provider == "ollama"
+
+    def _call_llm_stage(
+        self,
+        *,
+        stage: str,
+        prompt: str,
+        success_message: str,
+        failure_message: str,
+        data: dict[str, Any] | None = None,
+    ) -> str | None:
+        if not self._should_use_llm():
+            raise WriterAgentError("Es ist kein kompatibles LLM-Modell konfiguriert.")
+        try:
+            result = llm.generate_text(
+                provider=self.config.llm_provider,
+                model=self.config.llm_model,
+                prompt=prompt,
+                system_prompt=prompts.SYSTEM_PROMPT,
+                parameters=self.config.llm,
+                base_url=self.config.ollama_base_url,
+            )
+        except LLMGenerationError as exc:
+            event_data = {"provider": self.config.llm_provider, "model": self.config.llm_model}
+            if data:
+                event_data.update(data)
+            event_data["error"] = str(exc)
+            self._record_run_event(
+                stage,
+                f"{failure_message}: {exc}",
+                status="warning",
+                data=event_data,
+            )
+            return None
+
+        text = result.text.strip()
+        if not text:
+            event_data = {"provider": self.config.llm_provider, "model": self.config.llm_model}
+            if data:
+                event_data.update(data)
+            self._record_run_event(
+                stage,
+                f"{failure_message}: leere Antwort",
+                status="warning",
+                data=event_data,
+            )
+            return None
+
+        event_data = {
+            "provider": self.config.llm_provider,
+            "model": self.config.llm_model,
+            "characters": len(text),
+        }
+        if data:
+            event_data.update(data)
+        self._record_run_event(
+            stage,
+            success_message,
+            status="info",
+            data=event_data,
+        )
+        return text
+
+    def _count_words(self, text: str) -> int:
+        return len([token for token in text.split() if token.strip()])


### PR DESCRIPTION
## Summary
- rework `WriterAgent` so briefing, idea, outline, drafts, and revisions are produced by the configured LLM with compliance focused on redaction only
- update metadata and logging to reflect the LLM-driven pipeline and require a configured model before execution
- refresh agent and CLI tests to exercise the new behaviour and error handling paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca3dd682c483258b23bfa1d1fc96f6