### PR TITLE
Clarify briefing prompt to request JSON-only output

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -17,6 +17,7 @@ def test_prompt_templates_match_specification() -> None:
         "Verdichte folgende Angaben zu einem Arbeitsbriefing als kompaktes JSON "
         "mit Schlüsseln: goal, audience, tone, register, variant, constraints, "
         "key_terms, messages, seo_keywords (optional).\n"
+        "Gib ausschließlich ein JSON-Objekt ohne erläuternden Text zurück.\n"
         "**Eingaben:**\n"
         "title: {title}\n"
         "text_type: {text_type}\n"

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -10,6 +10,7 @@ SYSTEM_PROMPT: str = (
 # Normalisiert die Eingaben zu einem strukturierten Arbeitsbriefing.
 BRIEFING_PROMPT: str = """\
 Verdichte folgende Angaben zu einem Arbeitsbriefing als kompaktes JSON mit Schlüsseln: goal, audience, tone, register, variant, constraints, key_terms, messages, seo_keywords (optional).
+Gib ausschließlich ein JSON-Objekt ohne erläuternden Text zurück.
 **Eingaben:**
 title: {title}
 text_type: {text_type}


### PR DESCRIPTION
## Summary
- instruct the briefing prompt to return only a JSON object so downstream parsing remains reliable
- update prompt snapshot test to capture the stricter guidance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca9ee7755883258cf2edb4a4609f4a