### PR TITLE
Add timestamped final output file

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from collections import deque
 from pathlib import Path
@@ -122,6 +123,7 @@ def test_agent_generates_outputs_with_llm(tmp_path: Path, monkeypatch: pytest.Mo
     idea_output = (config.output_dir / "idea.txt").read_text(encoding="utf-8").strip()
     outline_output = (config.output_dir / "outline.txt").read_text(encoding="utf-8").strip()
     current_text = (config.output_dir / "current_text.txt").read_text(encoding="utf-8")
+    final_files = list(config.output_dir.glob("Final-*.txt"))
     metadata = json.loads((config.output_dir / "metadata.json").read_text(encoding="utf-8"))
     compliance = json.loads((config.output_dir / "compliance.json").read_text(encoding="utf-8"))
 
@@ -129,6 +131,10 @@ def test_agent_generates_outputs_with_llm(tmp_path: Path, monkeypatch: pytest.Mo
     assert "[ENTFERNT: vertrauliche]" in current_text
     assert idea_output == idea_text
     assert "Strategiepfad" in outline_output
+    assert len(final_files) == 1
+    final_file = final_files[0]
+    assert re.fullmatch(r"Final-\d{8}-\d{6}\.txt", final_file.name)
+    assert final_file.read_text(encoding="utf-8").strip() == final_output.strip()
     assert metadata["llm_model"] == "llama2"
     assert metadata["final_word_count"] == agent._count_words(final_output)
     assert metadata["rubric_passed"] is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import re
 import sys
 from collections import deque
 from pathlib import Path
@@ -112,10 +113,15 @@ def test_automatikmodus_runs_and_creates_outputs(tmp_path: Path, monkeypatch: py
     assert "[ENTFERNT: vertrauliche]" in captured.out
 
     current_text = (output_dir / "current_text.txt").read_text(encoding="utf-8")
+    final_files = list(output_dir.glob("Final-*.txt"))
     metadata = json.loads((output_dir / "metadata.json").read_text(encoding="utf-8"))
     compliance = json.loads((output_dir / "compliance.json").read_text(encoding="utf-8"))
 
     assert "[ENTFERNT: vertrauliche]" in current_text
+    assert len(final_files) == 1
+    final_file = final_files[0]
+    assert re.fullmatch(r"Final-\d{8}-\d{6}\.txt", final_file.name)
+    assert final_file.read_text(encoding="utf-8").strip() == current_text.strip()
     assert metadata["audience"] == "Vorstand"
     assert metadata["llm_model"] == "llama2"
     assert compliance["checks"]

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import json
 import re
+from datetime import datetime
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, List, Sequence
@@ -513,6 +514,7 @@ class WriterAgent:
                     data={"iteration": iteration},
                 )
 
+            final_output_path = self._write_final_output(draft)
             final_word_count = self._count_words(draft)
             self._write_metadata(draft)
             self._record_run_event(
@@ -532,6 +534,7 @@ class WriterAgent:
                 "complete",
                 "Automatikmodus erfolgreich abgeschlossen",
                 status="succeeded",
+                artifacts=[final_output_path],
                 data={"iterations": self.iterations, "steps": list(self.steps)},
             )
             return draft
@@ -1088,6 +1091,12 @@ class WriterAgent:
 
     def _write_text(self, path: Path, text: str) -> None:
         path.write_text(text.strip() + "\n", encoding="utf-8")
+
+    def _write_final_output(self, text: str) -> Path:
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        final_path = self.output_dir / f"Final-{timestamp}.txt"
+        self._write_text(final_path, text)
+        return final_path
 
     def _write_metadata(self, text: str) -> None:
         metadata = {


### PR DESCRIPTION
## Summary
- write the completed draft to a timestamped Final-YYYYMMDD-HHMMSS.txt file in the output directory
- record the final artifact on the completion event for traceability
- extend agent and CLI tests to assert the presence and contents of the new final file

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb9f1396608325af67c0b3ec93345b