### PR TITLE
Add runtime reporting to CLI and logs

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -392,9 +392,15 @@ def _run_automatikmodus(args: argparse.Namespace) -> int:
         final_text = agent.run()
     except WriterAgentError as exc:
         print(f"Automatikmodus konnte nicht abgeschlossen werden: {exc}", file=sys.stderr)
+        runtime_seconds = agent.runtime_seconds
+        if runtime_seconds is not None:
+            print(f"Gesamtlaufzeit: {runtime_seconds:.2f} Sekunden", file=sys.stderr)
         return 1
 
     print(final_text)
+    runtime_seconds = agent.runtime_seconds
+    if runtime_seconds is not None:
+        print(f"Gesamtlaufzeit: {runtime_seconds:.2f} Sekunden")
     return 0
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -142,6 +142,8 @@ def test_agent_generates_outputs_with_llm(tmp_path: Path, monkeypatch: pytest.Mo
     stages = {entry["stage"] for entry in compliance["checks"]}
     assert stages == {"draft", "revision_01"}
     assert agent._llm_generation and agent._llm_generation["status"] == "success"
+    assert agent.runtime_seconds is not None
+    assert agent.runtime_seconds >= 0
     assert not responses
 
 


### PR DESCRIPTION
## Summary
- capture the total runtime of the writer agent and include it in run and LLM logs
- expose the measured runtime via the CLI so it is printed on success and failure
- extend CLI and agent tests to validate runtime reporting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbaad984c883258cbab9f6ca35ef76