### PR TITLE
Add timestamps to run log entries

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import json
 import re
 import sys
 from collections import deque
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -142,6 +143,9 @@ def test_automatikmodus_runs_and_creates_outputs(tmp_path: Path, monkeypatch: py
         for line in (logs_dir / "run.log").read_text(encoding="utf-8").splitlines()
         if line.strip()
     ]
+    assert all("timestamp" in entry for entry in run_entries)
+    for entry in run_entries:
+        datetime.fromisoformat(entry["timestamp"])
     assert any(entry["step"] == "briefing" for entry in run_entries)
     assert any(entry["step"] == "revision_01" for entry in run_entries)
 
@@ -212,6 +216,9 @@ def test_cli_reports_llm_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
         for line in run_log.read_text(encoding="utf-8").splitlines()
         if line.strip()
     ]
+    assert all("timestamp" in entry for entry in run_entries)
+    for entry in run_entries:
+        datetime.fromisoformat(entry["timestamp"])
     assert any(entry["step"] == "error" and entry["status"] == "failed" for entry in run_entries)
 
     llm_log = logs_dir / "llm.log"

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -1170,6 +1170,7 @@ class WriterAgent:
         data: dict[str, Any] | None = None,
     ) -> None:
         event: dict[str, Any] = {"step": step, "status": status, "message": message}
+        event["timestamp"] = datetime.now().astimezone().isoformat(timespec="seconds")
         if artifacts:
             event["artifacts"] = [self._format_artifact_path(Path(artifact)) for artifact in artifacts]
         if data:


### PR DESCRIPTION
## Summary
- add ISO-8601 timestamps to recorded run events before log serialization
- extend CLI tests to assert timestamp presence and parseability in run logs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbaab21ca4832581eb147a9c012db3