### PR TITLE
Add temporary output cleanup before automatikmodus run

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,12 @@ def test_automatikmodus_runs_and_creates_outputs(tmp_path: Path, monkeypatch: py
     output_dir = tmp_path / "output"
     logs_dir = tmp_path / "logs"
 
+    output_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    stale_iteration = output_dir / "iteration_99.txt"
+    stale_iteration.write_text("veraltet", encoding="utf-8")
+
     monkeypatch.setattr(
         "wordsmith.ollama.OllamaClient.list_models",
         lambda self: [OllamaModel(name="llama2")],
@@ -111,6 +117,8 @@ def test_automatikmodus_runs_and_creates_outputs(tmp_path: Path, monkeypatch: py
 
     exit_code = main(args)
     captured = capsys.readouterr()
+
+    assert not stale_iteration.exists()
 
     assert exit_code == 0
     assert "[ENTFERNT: vertrauliche]" in captured.out

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,3 +78,29 @@ def test_loading_config_enforces_minimum_windows(tmp_path):
 
     assert config.context_length == MIN_CONTEXT_LENGTH
     assert config.token_limit == MIN_TOKEN_LIMIT
+
+
+def test_cleanup_temporary_outputs_removes_previous_run_files(tmp_path: Path) -> None:
+    config = Config(output_dir=tmp_path / "output", logs_dir=tmp_path / "logs")
+
+    temporary_files = [
+        config.output_dir / "briefing.json",
+        config.output_dir / "idea.txt",
+        config.output_dir / "outline.txt",
+        config.output_dir / "current_text.txt",
+        config.output_dir / "text_type_check.txt",
+        config.output_dir / "text_type_fix.txt",
+        config.output_dir / "iteration_07.txt",
+        config.output_dir / "reflection_03.txt",
+    ]
+    for path in temporary_files:
+        path.write_text("veraltet", encoding="utf-8")
+
+    final_file = config.output_dir / "Final-20240101-010101.txt"
+    final_file.write_text("final", encoding="utf-8")
+
+    config.cleanup_temporary_outputs()
+
+    for path in temporary_files:
+        assert not path.exists()
+    assert final_file.exists()

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -405,6 +405,7 @@ class WriterAgent:
         self._run_started_at = perf_counter()
         self._run_duration = None
         self.config.ensure_directories()
+        self.config.cleanup_temporary_outputs()
         self._idea_bullets.clear()
         self._compliance_audit.clear()
         self._run_events.clear()

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -15,6 +15,18 @@ MIN_CONTEXT_LENGTH: int = 2048
 MIN_TOKEN_LIMIT: int = 1024
 
 
+TEMPORARY_OUTPUT_PATTERNS: tuple[str, ...] = (
+    "briefing.json",
+    "idea.txt",
+    "outline.txt",
+    "current_text.txt",
+    "text_type_check.txt",
+    "text_type_fix.txt",
+    "iteration_*.txt",
+    "reflection_*.txt",
+)
+
+
 class ConfigError(Exception):
     """Raised when the configuration could not be loaded or validated."""
 
@@ -94,6 +106,17 @@ class Config:
 
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.logs_dir.mkdir(parents=True, exist_ok=True)
+
+    def cleanup_temporary_outputs(self) -> None:
+        """Delete transient artefacts from previous runs in the output directory."""
+
+        for pattern in TEMPORARY_OUTPUT_PATTERNS:
+            for path in self.output_dir.glob(pattern):
+                if path.is_file():
+                    try:
+                        path.unlink()
+                    except FileNotFoundError:  # pragma: no cover - defensive
+                        continue
 
     def _apply_minimum_limits(self) -> None:
         """Ensure configured context and generation windows meet minimum sizes."""


### PR DESCRIPTION
## Summary
- add a configuration helper that removes leftover temporary output artefacts from previous runs
- invoke the cleanup when the writer agent run starts so stale iteration files are purged automatically
- extend the configuration and CLI tests to cover the cleanup behaviour and ensure existing files are removed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbc59b17108325877a5819c1e86d61