### PR TITLE
Handle KeyboardInterrupt in CLI and add test

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -413,9 +413,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if not arguments:
         parser.print_help()
         return 1
-    parsed = parser.parse_args(arguments)
-    if hasattr(parsed, "func"):
-        return parsed.func(parsed)
+    try:
+        parsed = parser.parse_args(arguments)
+        if hasattr(parsed, "func"):
+            return parsed.func(parsed)
+    except KeyboardInterrupt:
+        print("\nAbbruch durch Benutzer.", file=sys.stderr)
+        return 130
     parser.print_help()
     return 1
 


### PR DESCRIPTION
## Summary
- handle KeyboardInterrupt in the CLI entry point so Ctrl+C exits cleanly with a dedicated message
- add a regression test to ensure the CLI returns exit code 130 when interrupted and wire up the required test config stub

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbc5fd90348325a563065c53256488