### PR TITLE
Format runtime output for long durations

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -57,11 +57,33 @@ class _ProgressPrinter:
             pass
 
 
+def _format_runtime(runtime_seconds: float) -> str:
+    if runtime_seconds < 60:
+        return f"{runtime_seconds:.2f} Sekunden"
+
+    hours = int(runtime_seconds // 3600)
+    minutes = int((runtime_seconds % 3600) // 60)
+    seconds = runtime_seconds - hours * 3600 - minutes * 60
+
+    def _format_unit(value: int, singular: str, plural: str) -> str:
+        return f"{value} {singular if value == 1 else plural}"
+
+    parts: list[str] = []
+    if hours:
+        parts.append(_format_unit(hours, "Stunde", "Stunden"))
+    if hours or minutes:
+        parts.append(_format_unit(minutes, "Minute", "Minuten"))
+    parts.append(f"{seconds:.2f} Sekunden")
+
+    formatted = " ".join(parts)
+    return f"{formatted} ({runtime_seconds:.2f} Sekunden)"
+
+
 def _print_runtime(runtime_seconds: float | None, stream: TextIO | None = None) -> None:
     if runtime_seconds is None:
         return
     target_stream = stream or sys.stderr
-    print(f"Gesamtlaufzeit: {runtime_seconds:.2f} Sekunden", file=target_stream)
+    print(f"Gesamtlaufzeit: {_format_runtime(runtime_seconds)}", file=target_stream)
 
 
 def _parse_bool(value: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
+import cli
 from cli import (
     DEFAULT_AUDIENCE,
     DEFAULT_CONSTRAINTS,
@@ -23,6 +24,24 @@ from cli import (
 from wordsmith import llm
 from wordsmith.ollama import OllamaModel
 from wordsmith.config import Config
+
+
+def test_print_runtime_formats_minutes_and_seconds() -> None:
+    buffer = io.StringIO()
+    cli._print_runtime(125.5, stream=buffer)
+    assert (
+        buffer.getvalue().strip()
+        == "Gesamtlaufzeit: 2 Minuten 5.50 Sekunden (125.50 Sekunden)"
+    )
+
+
+def test_print_runtime_formats_hours_minutes_and_seconds() -> None:
+    buffer = io.StringIO()
+    cli._print_runtime(3723.5, stream=buffer)
+    assert (
+        buffer.getvalue().strip()
+        == "Gesamtlaufzeit: 1 Stunde 2 Minuten 3.50 Sekunden (3723.50 Sekunden)"
+    )
 
 
 def test_automatikmodus_requires_arguments() -> None:


### PR DESCRIPTION
## Summary
- format CLI runtime output to include hours, minutes, and seconds for longer runs
- add helper to keep the original second-based display for short runs while appending breakdown for longer ones
- extend CLI tests to cover the new runtime formatting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc523a210083258d989473e90b28d9