### PR TITLE
Restore legacy prompts and add setter

### DIFF
--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -1,200 +1,154 @@
-"""Prompt templates used by WriterAgent (überarbeitet)."""
+"""Prompt templates used by WriterAgent."""
 
-# ------------------------------
-# Globale System-Prompts
-# ------------------------------
+from __future__ import annotations
 
-SYSTEM_PROMPT = (
-    "Du bist ein präziser deutschsprachiger Autor. "
-    "Deine Texte sind klar strukturiert, aktiv formuliert, redundanzarm und adressatengerecht. "
-    "Vermeide Wiederholungen und Füllwörter und achte besonders auf die inhaltliche Qualität des Textes. "
-    "Dein Thema lautet: {topic}. Du verfasst einen {text_type}. "
-    "Halte den Zielumfang von etwa {word_count} Wörtern ein (±10%). "
-    "Gib ausschließlich den vollständigen Text zurück – ohne Erklärungen, ohne Listen, ohne Meta-Kommentare."
+_DEFAULT_SYSTEM_PROMPT = (
+    "Du bist ein kreativer deutschsprachiger Autor. Du erfindest keine Fakten. "
+    "Vermeide Wiederholungen und Füllwörter. Deine Texte sind klar strukturiert, "
+    "aktiv formuliert, redundanzarm und adressatengerecht."
 )
 
-# Prompts für interaktiven/Legacy-Modus
-META_SYSTEM_PROMPT = (
-    "Du bist ein kreativer, strukturierter Schreibcoach, der Autorinnen hilft, den nächsten "
-    "sinnvollen Schritt zu planen und ihre Texte zu verfeinern."
+SYSTEM_PROMPT: str = _DEFAULT_SYSTEM_PROMPT
+
+
+def set_system_prompt(prompt: str | None) -> None:
+    """Configure the system prompt for subsequent LLM interactions."""
+
+    global SYSTEM_PROMPT
+
+    if prompt is None:
+        SYSTEM_PROMPT = _DEFAULT_SYSTEM_PROMPT
+        return
+
+    cleaned = str(prompt).strip()
+    SYSTEM_PROMPT = cleaned or _DEFAULT_SYSTEM_PROMPT
+
+
+BRIEFING_PROMPT = """\
+Verdichte folgende Angaben zu einem konsistenten Arbeitsbriefing als strikt valides JSON-Objekt (UTF-8, ohne Kommentare).
+Erstelle genau die Schlüssel: goal, audience, tone, register, variant, constraints, key_terms, messages, seo_keywords (optional).
+- Formuliere `goal` als prägnanten Zielsatz.
+- Gib `audience`, `tone`, `register`, `variant`, `constraints` als getrimmte Strings zurück (fehlende Angaben → `[KLÄREN: …]`).
+- Liste `key_terms`, `messages` und `seo_keywords` als Arrays mit einzelnen Strings (fehlende Angaben → leeres Array; Einträge trimmen, Duplikate entfernen).
+- Interpretiere Eingaben wie „keine“ oder leere Werte bei Keywords als leeres Array.
+Gib ausschließlich ein JSON-Objekt ohne erläuternden Text zurück.
+**Eingaben:**
+title: {title}
+text_type: {text_type}
+audience: {audience}
+tone: {tone}
+register: {register}
+variant: {variant}
+constraints: {constraints}
+seo_keywords: {seo_keywords}
+notes: {content}
+"""
+
+IDEA_IMPROVEMENT_PROMPT = """\
+Überarbeite diesen Rohinhalt **ohne neue Fakten** und in der vorhandenen Sprache.
+Liefere das Ergebnis in folgender Markdown-Struktur:
+1. **Überarbeitete Fassung:** optimierter Fließtext mit klarer Dramaturgie.
+2. **Unklarheiten:** Bullet-Liste mit `[KLÄREN: …]`-Hinweisen für Informationslücken.
+3. **Kernaussagen:** Bullet-Liste der wichtigsten Aussagen (ein Bullet pro Gedanke).
+4. **Summary:** exakt ein Satz, der die Idee kondensiert.
+**Rohinhalt:** {content}
+"""
+
+OUTLINE_PROMPT = """\
+Erzeuge eine hierarchische Gliederung für `{text_type}` zu `{title}` basierend auf dem Briefing:
+{briefing_json}
+Nutze nummerierte Einträge (`1.`, `1.1` …) mit dem Format `{{nummer}}. {{Titel}} (Rolle: …; Wortbudget: …; Liefergegenstand: …)`.
+Berücksichtige strategische Übergänge und stelle sicher, dass die Wortbudgets in Summe {word_count} Wörter ergeben (Rundungen dokumentieren).
+Keine Fakten erfinden; nutze bei Bedarf Platzhalter.
+"""
+
+OUTLINE_IMPROVEMENT_PROMPT = """\
+Prüfe und verbessere die Outline: entferne Überschneidungen, füge fehlende Brücken, balanciere Budgets (Summe = {word_count}).
+Vorgehen:
+1. Liste konkrete Probleme oder Risiken (Stichpunkte).
+2. Präsentiere die optimierte Outline im Format `{{nummer}}. {{Titel}} (Rolle: …; Wortbudget: …; Liefergegenstand: …)`.
+3. Bestätige die Gesamtsumme als `Gesamt: {word_count} Wörter` (Rundungsabweichungen begründen).
+Behalte Faktenneutralität.
+"""
+
+SECTION_PROMPT = """\
+Schreibe Abschnitt {section_number} „{section_title}“ (Rolle: {role}) mit Ziel `{deliverable}`.
+Nutze Briefing, Outline und bisherige Abschnitte für Kohärenz, Terminologie und Übergänge.
+Regeln:
+- Liefere ausschließlich den Abschnittsfließtext ohne eigene Überschrift.
+- Verwende aktive Verben, vermeide Füllphrasen und halte das Register konsistent.
+- Knüpfe an den vorherigen Abschnitt an und baue einen logischen Ausblick auf den nächsten.
+- **Keine** erfundenen Fakten; fehlende Details → Platzhalter in eckigen Klammern.
+Zielwortzahl: {budget}.
+**Bisheriger Kontext (Kurz-Recap)**: {previous_section_recap}
+"""
+
+TEXT_TYPE_CHECK_PROMPT = """\
+Prüfe den Text gegen die Rubrik für `{text_type}` (Kriterienliste siehe oben).
+Strukturiere deine Antwort so:
+1. **Gesamturteil:** `PASS` oder `FAIL` mit kurzer Begründung.
+2. **Abweichungen:** Markdown-Tabelle mit Spalten `Kriterium | Beschreibung | Fundstelle | Dringlichkeit`. Wenn keine Abweichungen vorliegen, schreibe `Keine Abweichungen`.
+3. **Empfehlungen:** Bullet-Liste mit umsetzbaren Korrekturschritten.
+"""
+
+TEXT_TYPE_FIX_PROMPT = """\
+Korrigiere nur die genannten Abweichungen **minimal-invasiv**, ohne Faktenzuwachs. Erhalte Ton, Terminologie, Struktur.
+Vorgehen:
+1. Übernimm ausschließlich die notwendigen Änderungen direkt im Text (keine Anmerkungen).
+2. Bewahre Formatierung, Abschnittsüberschriften und Wortbudgets soweit möglich.
+3. Nutze vorhandene Platzhalter weiter oder markiere neue Informationslücken mit `[KLÄREN: …]`.
+Gib nur den aktualisierten Text zurück.
+"""
+
+REVISION_PROMPT = """\
+Überarbeite zielgerichtet nach diesen Prioritäten: Klarheit, Flow, Terminologie, Wiederholungen, Rhythmus, starke Verben, Abschluss, Register, Variantenspezifika.
+Arbeite Schritt für Schritt: plane die Eingriffe kurz, führe sie dann aus.
+Liefere den überarbeiteten Text in Markdown ohne Meta-Kommentare; bei fehlenden Daten setze Platzhalter.
+"""
+
+COMPLIANCE_HINT_INSTRUCTION = (
+    "Falls Compliance-Hinweise nötig sind, füge sie als separate Zeile im Format `[COMPLIANCE-HINWEIS: …]` am Ende an."
 )
 
-META_PROMPT = (
-    "Du arbeitest an einem {text_type} mit dem Titel: {title}\n"
-    "Er behandelt folgenden Inhalt: {content}\n"
-    "Die gewünschte Länge beträgt etwa {word_count} Wörter (±10%).\n"
-    "Aktueller Stand des Textes:\n{current_text}\n\n"
-    "Beschreibe den nächsten sinnvollen Schritt der Geschichte, der den Text literarisch vertiefen würde. "
-    "Achte darauf, dass Atmosphäre, Spannung und innere Konflikte verstärkt werden und die Figuren "
-    "lebendiger, widersprüchlicher und psychologisch nachvollziehbarer wirken. "
-    "Lege Wert auf subtile Andeutungen, emotionale Zwischentöne und mögliche symbolische Elemente, "
-    "die den Text dichter und vielschichtiger machen. "
-    "Formuliere ausschließlich einen präzisen Prompt für ein LLM, der genau diesen nächsten sinnvollen Schritt beschreibt, "
-    "so dass daraus eine kreative und literarisch hochwertige Erweiterung der Geschichte entstehen kann. "
-    "Gib nur den Prompt zurück."
-)
 
-INITIAL_AUTO_SYSTEM_PROMPT = (
-    "Du bist eine erfahrene Autorin, die aus kurzen Vorgaben einen hochwertigen ersten Rohtext entwickelt. "
-    "Zielumfang: {word_count} Wörter (±10%)."
-)
+def build_revision_prompt(include_compliance_hint: bool = False) -> str:
+    """Return the revision prompt, optionally with the compliance hint appended."""
 
-# ------------------------------
-# Überarbeiteter Automatik-Modus
-# ------------------------------
+    prompt = REVISION_PROMPT.strip()
+    if include_compliance_hint:
+        return f"{prompt}\n{COMPLIANCE_HINT_INSTRUCTION}"
+    return prompt
 
-BRIEFING_PROMPT = (
-    "Verdichte folgende Angaben zu einem Arbeitsbriefing als kompaktes JSON mit Schlüsseln: "
-    "goal, audience, tone, register, variant, constraints, key_terms, messages, seo_keywords (optional), "
-    "word_count.\n"
-    "**Eingaben:**\n"
-    "title: {title}\n"
-    "text_type: {text_type}\n"
-    "audience: {audience}\n"
-    "tone: {tone}\n"
-    "register: {register}\n"
-    "variant: {variant}\n"
-    "constraints: {constraints}\n"
-    "seo_keywords: {seo_keywords}\n"
-    "notes: {content}\n"
-    "word_count: {word_count}\n"
-    "Gib ausschließlich valides, minimales JSON zurück (keine Prosa, keine Kommentare)."
-)
 
-IDEA_IMPROVEMENT_SYSTEM_PROMPT = (
-    "Du überarbeitest Ideen, korrigierst Rechtschreib- und Grammatikfehler und formulierst sie klarer."
-)
+REFLECTION_PROMPT = """\
+Nenne die 3 wirksamsten nächsten Verbesserungen als priorisierte Markdown-Liste (1 = höchste Wirkung).
+Jeder Punkt: maximal 15 Wörter, klar umsetzbar, mit Hinweis auf den betroffenen Abschnitt.
+"""
 
-IDEA_IMPROVEMENT_PROMPT = (
-    "Überarbeite diesen Rohinhalt als erfahrene Autorin.\n"
-    "1) Straffe Sprache, 2) markiere Unklarheiten mit `[KLÄREN: …]`, 3) gib Kernaussagen als Bullets + 1-Satz-Summary.\n"
-    "**Rohinhalt:** {content}\n"
-    "Halte den Informationsumfang in etwa konstant; kürze nur Mikro-Redundanzen und gleiche entstandene Kürzungen durch präzise Ergänzungen aus."
-)
+FINAL_DRAFT_PROMPT = """\
+Schreibe den finalen {text_type} zum Thema "{title}" mit etwa {word_count} Wörtern (±3 %).
+Arbeite strikt mit den folgenden Informationen und Regeln.
 
-OUTLINE_SYSTEM_PROMPT = (
-    "Du gliederst Themen in übersichtliche, gut strukturierte Outlines und achtest auf klare Hierarchien "
-    "sowie eine sinnvolle Reihenfolge."
-)
+Briefing:
+{briefing_json}
 
-OUTLINE_PROMPT = (
-    "Erzeuge eine hierarchische Gliederung für `{text_type}` zu `{title}` basierend auf dem Briefing:\n"
-    "{briefing_json}\n"
-    "Für jeden Abschnitt: Nummer, Titel, Rollenfunktion, Wortbudget (Integer), Liefergegenstand. "
-    "Weise realistische Wortbudgets zu, sodass die Summe genau {word_count} beträgt. "
-    "Gib ausschließlich die Outline zurück (ohne Prosa) und füge am Ende eine Kontrollzeile an: "
-    "`KONTROLLSUMME_WÖRTER = <Summe>`."
-)
+Gliederung:
+{outline}
 
-OUTLINE_IMPROVEMENT_SYSTEM_PROMPT = (
-    "Du überarbeitest Outlines, vertiefst die Charakterisierung der Figuren und sorgst für eine klare, konsistente Struktur."
-)
+Kernaussagen aus der Idee:
+{idea_bullets}
 
-OUTLINE_IMPROVEMENT_PROMPT = (
-    "Prüfe und verbessere die Outline: entferne Überschneidungen, füge fehlende Brücken, balanciere Budgets "
-    "(Summe MUSS = {word_count} sein). "
-    "Behalte Faktenneutralität.\n\nOutline:\n{outline}\n"
-    "Gib ausschließlich die bereinigte Outline zurück und wiederhole am Ende die Kontrollzeile "
-    "`KONTROLLSUMME_WÖRTER = <Summe>`."
-)
+Regeln:
+- Tonfall: {tone}
+- Register: {register}
+- Sprachvariante: {variant_hint}
+- Quellenmodus: {sources_mode}
+- Zusätzliche Constraints: {constraints}
+- SEO-Keywords: {seo_keywords}
+- Keine neuen Fakten erfinden; nutze Platzhalter wie [KLÄREN:], [KENNZAHL], [QUELLE], [DATUM].
+- Übernehme Zwischenüberschriften exakt gemäß Gliederung (`## {{nummer}}. {{Titel}}`) und halte die Wortbudgets pro Abschnitt grob ein.
+- Sorg für einen packenden Einstieg, klare Übergänge zwischen den Abschnitten und einen CTA, der die adressierte Zielgruppe anspricht.
+- Nutze Keywords natürlich im Fließtext und optimiere für Lesbarkeit und SEO.
 
-SECTION_SYSTEM_PROMPT = (
-    "Du schreibst spannende Prosatexte auf Deutsch und hältst dich strikt an die Outline. "
-    "Du bleibst konsequent im Stil, in der Terminologie und in der Perspektive."
-)
-
-SECTION_PROMPT = (
-    "Schreibe Abschnitt {section_number} „{section_title}“ (Rolle: {role}) mit Ziel `{deliverable}`.\n"
-    "Nutze Briefing und bisherige Abschnitte (Kohärenz, Terminologie).\n"
-    "Briefing: {briefing_json}\n"
-    "Bisheriger Kontext (Kurz-Recap): {previous_section_recap}\n"
-    "Regeln: aktive Verben, keine Füllphrasen, natürliche Übergänge, keine erfundenen Fakten (Platzhalter bei Lücken), "
-    "konsequente Erzählperspektive.\n"
-    "Zielwortzahl: {budget} (±10%).\n\n"
-    "Gib ausschließlich den vollständigen Fließtext des Abschnitts zurück – ohne Meta-Kommentare und ohne Listen. "
-    "Wenn dein Ergebnis außerhalb des Zielkorridors liegt, gib stattdessen genau `RETRY_LENGTH` aus."
-)
-
-SECTION_CONTINUE_PROMPT = (
-    "Der Abschnitt {section_number} „{section_title}“ (Rolle: {role}) mit Ziel `{deliverable}` ist noch zu kurz. "
-    "Führe ihn fort und erweitere ihn um etwa {budget} Wörter (±10%), ohne den bisherigen Text zu wiederholen. "
-    "Füge nahtlos an, achte auf Kohärenz, Motivführung und Rhythmus.\n"
-    "Briefing: {briefing_json}\n"
-    "Bisheriger Abschnitt: {existing_text}\n"
-    "Bisheriger Kontext (Kurz-Recap): {previous_section_recap}\n\n"
-    "Gib ausschließlich den neuen, anzuhängenden Fließtext zurück. "
-    "Wenn dein Ergebnis außerhalb des Zielkorridors liegt, gib stattdessen genau `RETRY_LENGTH` aus."
-)
-
-REVISION_SYSTEM_PROMPT = (
-    "Du überarbeitest Texte präzise, verbesserst Stil, Kohärenz und Grammatik und orientierst dich an einer vorgegebenen Outline. "
-    "WICHTIG: Erhalte den Gesamtumfang (±10% gegenüber dem Ist-Text oder den Abschnittsbudgets); "
-    "wenn du straffst, gleiche die Kürzung durch gehaltvolle Ergänzungen (Details, Sinneseindrücke, Subtext) aus. "
-    "Lösche keine Abschnitte; reduziere nur Mikro-Redundanz."
-)
-
-REVISION_PROMPT = (
-    "Überarbeite zielgerichtet nach diesen Prioritäten: Klarheit & Prägnanz, Flow & Übergänge, Terminologie-Konsistenz, "
-    "Wiederholungen tilgen (nur mikro), Rhythmus variieren, spezifische Verben/Nomen stärken, Schlussteil schärfen "
-    "(CTA/Resolution), Registersicherheit ({register}), Variantenspezifika ({variant}).\n\n"
-    "Halte den Umfang stabil (±10% gegenüber dem aktuellen Text). "
-    "Wenn Kürzungen unvermeidlich sind, gleiche sie durch stilkongruente Ergänzungen (Szenendetails, Dialognuancen, "
-    "innere Regungen, Atmosphäre) aus.\n\n"
-    "Aktueller Text:\n{current_text}\n\n"
-    "Gib ausschließlich den vollständig überarbeiteten Text zurück – ohne Meta-Kommentare. "
-    "Wenn dein Ergebnis außerhalb des Längenkorridors liegt, gib stattdessen genau `RETRY_LENGTH` aus."
-)
-
-# ------------------------------
-# Interaktiver Modus & Utilities
-# ------------------------------
-
-PROMPT_CRAFTING_SYSTEM_PROMPT = (
-    "Du formulierst knappe, klare Prompts für andere Sprachmodelle und vermeidest Mehrdeutigkeiten."
-)
-
-PROMPT_CRAFTING_PROMPT = (
-    "Formuliere einen klaren und konkreten Prompt für ein LLM, "
-    "um die Aufgabe '{task}' zum Thema '{topic}' umzusetzen. "
-    "Gib nur den Prompt zurück."
-)
-
-STEP_SYSTEM_PROMPT = (
-    "Du führst als erfahrene Autorin eine begonnene Erzählung stilgetreu fort und greifst Figuren, Ton und Spannung des bisherigen Textes auf."
-)
-
-STEP_PROMPT = (
-    "{prompt}\n\n"
-    "Aktueller Text:\n{current_text}\n\n"
-    "Nächster Abschnitt (halte den bisherigen Umfangstrend bei und peile insgesamt {word_count} Wörter ±10% an):\n"
-    "Gib ausschließlich Fließtext zurück; keine Meta-Kommentare. "
-    "Wenn der erzeugte Abschnitt offensichtlich zu kurz/zu lang ist, gib stattdessen `RETRY_LENGTH` aus."
-)
-
-TEXT_TYPE_CHECK_SYSTEM_PROMPT = (
-    "Du prüfst als seit 20 Jahren erfahrene Lektorin Texte darauf, ob sie den Merkmalen der angegebenen Textart entsprechen."
-)
-
-TEXT_TYPE_CHECK_PROMPT = (
-    "Prüfe den folgenden Text gegen die Rubrik für `{text_type}`. Liste konkrete Abweichungen und betroffene Stellen.\n\n"
-    "Text:\n{current_text}\n"
-)
-
-TEXT_TYPE_FIX_SYSTEM_PROMPT = (
-    "Du überarbeitest Texte anhand eines Textchecks und behebst die genannten Mängel präzise."
-)
-
-TEXT_TYPE_FIX_PROMPT = (
-    "Der Rubrik-Check hat ergeben, dass es folgende Abweichungen im Text gibt:\n"
-    "{issues}\n"
-    "Behebe sie im folgenden Text und liefere die verbesserte Version, "
-    "ohne den Gesamtumfang wesentlich zu reduzieren (±10% gegenüber dem Ist-Text). "
-    "Kürzungen nur lokal und durch inhaltliche Ergänzungen ausgleichen.\n\n"
-    "{current_text}\n\n"
-    "Gib ausschließlich den vollständigen, verbesserten Text zurück. "
-    "Wenn dein Ergebnis außerhalb des Längenkorridors liegt, gib stattdessen genau `RETRY_LENGTH` aus."
-)
-
-REFLECTION_PROMPT = (
-    "Nenne die 3 wirksamsten nächsten Verbesserungen (knapp, umsetzbar)."
-)
+Gib ausschließlich den ausgearbeiteten Text in Markdown zurück.
+"""


### PR DESCRIPTION
## Summary
- restore the prompt templates to the documented/tested specification
- add a setter that applies configured system prompts with a sensible default
- expose a helper to append compliance hints to revision prompts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd0f0e5e00832598dca92c81b7b223