### PR TITLE
Prevent stage system prompts from being overwritten

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -77,14 +77,13 @@ def test_load_prompt_config_respects_custom_system_prompt(tmp_path: Path) -> Non
     )
 
     try:
+        original_stage_prompts = dict(prompts.STAGE_SYSTEM_PROMPTS)
+
         prompts.set_system_prompt("Individueller Prompt")
         prompts.load_prompt_config(replacement_path)
 
         assert prompts.SYSTEM_PROMPT == "Individueller Prompt"
-        assert all(
-            value == "Individueller Prompt"
-            for value in prompts.STAGE_SYSTEM_PROMPTS.values()
-        )
+        assert dict(prompts.STAGE_SYSTEM_PROMPTS) == original_stage_prompts
 
         prompts.set_system_prompt(None)
         assert prompts.SYSTEM_PROMPT == "Neuer Standard"
@@ -115,3 +114,16 @@ def test_set_system_prompt_for_specific_stage() -> None:
             assert prompts.STAGE_SYSTEM_PROMPTS[stage] == value
     finally:
         prompts.set_system_prompt(None, stage="outline")
+
+
+def test_set_system_prompt_does_not_override_stage_prompts() -> None:
+    """A global system prompt override keeps the stage-specific prompts intact."""
+
+    prompts.set_system_prompt(None)
+    original_stage_prompts = dict(prompts.STAGE_SYSTEM_PROMPTS)
+
+    try:
+        prompts.set_system_prompt("Global Override")
+        assert dict(prompts.STAGE_SYSTEM_PROMPTS) == original_stage_prompts
+    finally:
+        prompts.set_system_prompt(None)

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -185,9 +185,6 @@ def set_system_prompt(prompt: str | None, *, stage: str | None = None) -> None:
     cleaned = str(prompt).strip()
     value = cleaned or _DEFAULT_SYSTEM_PROMPT
     SYSTEM_PROMPT = value
-    for stage_name, prefix in _STAGE_PROMPT_ORDER:
-        _STAGE_SYSTEM_PROMPTS[stage_name] = value
-        globals()[f"{prefix}_SYSTEM_PROMPT"] = value
 
 
 def build_revision_prompt(include_compliance_hint: bool = False) -> str:


### PR DESCRIPTION
## Summary
- keep stage-specific system prompts from the prompt configuration when applying a global system prompt override
- extend prompt tests to cover the updated behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce341afbe48325998797b187cb8c31