### PR TITLE
Add stage-specific generation parameters and telemetry

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,11 +37,12 @@ def test_adjust_for_word_count_scales_limits_and_sets_determinism():
     assert config.word_count == 600
     assert config.context_length == 8192
     assert config.token_limit == 8192
-    assert config.llm.temperature == 0.8
-    assert config.llm.top_p == 0.9
-    assert config.llm.presence_penalty == 0.0
-    assert config.llm.frequency_penalty == 0.3
+    assert config.llm.temperature == 0.7
+    assert config.llm.top_p == 1.0
+    assert config.llm.presence_penalty == 0.05
+    assert config.llm.frequency_penalty == 0.05
     assert config.llm.seed == 42
+    assert config.llm.num_predict == config.token_limit
 
 
 def test_config_uses_ollama_as_default_llm_provider():

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -41,6 +41,9 @@ def test_prompt_templates_match_configuration() -> None:
             f"{stage}_system_prompt"
         ]
         expected_stage_systems[stage] = config_data[f"{stage}_system_prompt"]
+        assert dict(prompts.STAGE_PROMPT_PARAMETERS[stage]) == config_data[
+            f"{stage}_parameters"
+        ]
 
     assert dict(prompts.STAGE_SYSTEM_PROMPTS) == expected_stage_systems
     assert (

--- a/wordsmith/llm.py
+++ b/wordsmith/llm.py
@@ -30,6 +30,8 @@ def _prepare_options(parameters: LLMParameters) -> Dict[str, Any]:
     }
     if getattr(parameters, "seed", None) is not None:
         options["seed"] = parameters.seed
+    if getattr(parameters, "num_predict", None) is not None:
+        options["num_predict"] = int(parameters.num_predict)
     return options
 
 

--- a/wordsmith/prompts_config.json
+++ b/wordsmith/prompts_config.json
@@ -20,5 +20,65 @@
     "reflection_system_prompt": "Du bist ein reflektierter Schreibmentor. Du identifizierst die wirksamsten nächsten Verbesserungen fokussiert und priorisiert.",
     "reflection_prompt": "Nenne die 3 wirksamsten nächsten Verbesserungen als priorisierte Markdown-Liste (1 = höchste Wirkung).\nJeder Punkt: maximal 15 Wörter, klar umsetzbar, mit Hinweis auf den betroffenen Abschnitt oder Absatz.\n",
     "final_draft_system_prompt": "Du bist ein erfahrener Hauptautor. Du orchestrierst alle Vorgaben zu einem überzeugenden, konsistenten finalen Text.",
-    "final_draft_prompt": "Schreibe den finalen {text_type} zum Thema \"{title}\" mit etwa {word_count} Wörtern (±3 %).\nArbeite strikt mit den folgenden Informationen und Regeln.\n\nBriefing:\n{briefing_json}\n\nGliederung:\n{outline}\n\nKernaussagen aus der Idee:\n{idea_bullets}\n\nRegeln:\n- Tonfall: {tone}\n- Register: {register}\n- Sprachvariante: {variant_hint}\n- Quellenmodus: {sources_mode}\n- Zusätzliche Constraints: {constraints}\n- SEO-Keywords: {seo_keywords}\n- Übernimm Zwischenüberschriften exakt gemäß Gliederung (`## {{nummer}}. {{Titel}}`) und halte die Wortbudgets pro Abschnitt grob ein.\n- Keine neuen Fakten erfinden; nutze Platzhalter wie [KLÄREN:], [KENNZAHL], [QUELLE], [DATUM].\n- Sorge für einen packenden Einstieg, klare Übergänge und einen zielgruppengerechten Abschluss/CTA.\n- Verwende Keywords organisch, optimiere für Lesbarkeit und SEO.\nGib ausschließlich den ausgearbeiteten Text in Markdown zurück.\n"
+    "final_draft_prompt": "Schreibe den finalen {text_type} zum Thema \"{title}\" mit etwa {word_count} Wörtern (±3 %).\nArbeite strikt mit den folgenden Informationen und Regeln.\n\nBriefing:\n{briefing_json}\n\nGliederung:\n{outline}\n\nKernaussagen aus der Idee:\n{idea_bullets}\n\nRegeln:\n- Tonfall: {tone}\n- Register: {register}\n- Sprachvariante: {variant_hint}\n- Quellenmodus: {sources_mode}\n- Zusätzliche Constraints: {constraints}\n- SEO-Keywords: {seo_keywords}\n- Übernimm Zwischenüberschriften exakt gemäß Gliederung (`## {{nummer}}. {{Titel}}`) und halte die Wortbudgets pro Abschnitt grob ein.\n- Keine neuen Fakten erfinden; nutze Platzhalter wie [KLÄREN:], [KENNZAHL], [QUELLE], [DATUM].\n- Sorge für einen packenden Einstieg, klare Übergänge und einen zielgruppengerechten Abschluss/CTA.\n- Verwende Keywords organisch, optimiere für Lesbarkeit und SEO.\nGib ausschließlich den ausgearbeiteten Text in Markdown zurück.\n",
+    "briefing_parameters": {
+        "temperature": 0.65,
+        "top_p": 1.0,
+        "presence_penalty": 0.05,
+        "frequency_penalty": 0.05
+    },
+    "idea_improvement_parameters": {
+        "temperature": 0.75,
+        "top_p": 1.0,
+        "presence_penalty": 0.05,
+        "frequency_penalty": 0.05
+    },
+    "outline_parameters": {
+        "temperature": 0.7,
+        "top_p": 1.0,
+        "presence_penalty": 0.05,
+        "frequency_penalty": 0.05
+    },
+    "outline_improvement_parameters": {
+        "temperature": 0.7,
+        "top_p": 1.0,
+        "presence_penalty": 0.05,
+        "frequency_penalty": 0.05
+    },
+    "section_parameters": {
+        "temperature": 0.7,
+        "top_p": 1.0,
+        "presence_penalty": 0.05,
+        "frequency_penalty": 0.05
+    },
+    "text_type_check_parameters": {
+        "temperature": 0.6,
+        "top_p": 1.0,
+        "presence_penalty": 0.05,
+        "frequency_penalty": 0.05
+    },
+    "text_type_fix_parameters": {
+        "temperature": 0.6,
+        "top_p": 1.0,
+        "presence_penalty": 0.05,
+        "frequency_penalty": 0.05
+    },
+    "revision_parameters": {
+        "temperature": 0.65,
+        "top_p": 1.0,
+        "presence_penalty": 0.05,
+        "frequency_penalty": 0.05
+    },
+    "reflection_parameters": {
+        "temperature": 0.7,
+        "top_p": 1.0,
+        "presence_penalty": 0.05,
+        "frequency_penalty": 0.05
+    },
+    "final_draft_parameters": {
+        "temperature": 0.68,
+        "top_p": 1.0,
+        "presence_penalty": 0.05,
+        "frequency_penalty": 0.05
+    }
 }


### PR DESCRIPTION
## Summary
- tighten default generation settings and scale num_predict with the token budget
- load per-stage parameter overrides from the prompt configuration and expose them to the agent
- capture detailed LLM telemetry per prompt stage and persist it alongside existing logs
- update unit tests to cover the new configuration values, prompt parameters, and telemetry output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce7514697483258b198553326324f0