### PR TITLE
Add reflection stage after revisions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -547,8 +547,8 @@ def _run_automatikmodus(args: argparse.Namespace) -> int:
 
     prompts.set_system_prompt(config.system_prompt)
 
-    # The pipeline records six completed stages plus a final completion event.
-    total_steps = 7 + max(args.iterations, 0)
+    # The pipeline records six baseline completions plus revisions and reflections.
+    total_steps = 7 + max(args.iterations, 0) * 2
     progress_printer = _ProgressPrinter(total_steps)
 
     agent = WriterAgent(

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -526,6 +526,18 @@ class WriterAgent:
                     data={"iteration": iteration},
                 )
 
+                reflection = self._generate_reflection(draft, iteration)
+                if reflection:
+                    reflection_path = self.output_dir / f"reflection_{iteration + 1:02d}.txt"
+                    self._write_text(reflection_path, reflection)
+                    self.steps.append(f"reflection_{iteration:02d}")
+                    self._record_run_event(
+                        f"reflection_{iteration:02d}",
+                        f"Reflexion {iteration:02d} abgeschlossen",
+                        artifacts=[reflection_path],
+                        data={"iteration": iteration},
+                    )
+
             final_output_path = self._write_final_output(draft)
             final_word_count = self._count_words(draft)
             self._write_metadata(draft)
@@ -1093,6 +1105,22 @@ class WriterAgent:
             success_message=f"Revision {iteration:02d} generiert",
             failure_message=f"Revision {iteration:02d} fehlgeschlagen",
             data={"iteration": iteration, "target_words": self.word_count},
+        )
+
+    def _generate_reflection(self, text: str, iteration: int) -> str | None:
+        prompt = (
+            prompts.REFLECTION_PROMPT.strip()
+            + "\n\nText:\n"
+            + text.strip()
+        )
+        return self._call_llm_stage(
+            stage=f"reflection_{iteration:02d}_llm",
+            prompt_type="reflection",
+            prompt=prompt,
+            system_prompt=prompts.REFLECTION_SYSTEM_PROMPT,
+            success_message=f"Reflexion {iteration:02d} generiert",
+            failure_message=f"Reflexion {iteration:02d} fehlgeschlagen",
+            data={"iteration": iteration, "phase": "reflection", "target_words": self.word_count},
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add an LLM-driven reflection step after each revision that saves the notes and logs the run events
- adjust the CLI progress step calculation so the additional reflection stages are counted
- extend the integration tests to cover the extra LLM responses, generated reflection files, and log entries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce9538eef08325a01c97b7dcf52b05