### PR TITLE
Use user-provided context in revision prompts

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -370,14 +370,18 @@ def test_revision_stage_is_stateless(
     result = agent._revise_with_llm(source_text, 1, {"goal": "Test"})
 
     assert result == "Überarbeitet"
-    assert captured["prompt"] == source_text.strip()
-    assert "Briefing" not in captured["prompt"]
+    prompt_text = captured["prompt"]
+    assert prompt_text.startswith("Überarbeite den folgenden Memo")
+    assert "Zielgruppe: Team" in prompt_text
+    assert "\"goal\": \"Test\"" in prompt_text
+    assert "Text zur Überarbeitung:\nAktueller Text mit Kontext." in prompt_text
     base_prompt = prompts.REVISION_SYSTEM_PROMPT.strip()
     assert captured["system_prompt"].startswith(base_prompt)
     compliance_instruction = prompts.COMPLIANCE_HINT_INSTRUCTION.strip()
     if compliance_instruction:
         assert compliance_instruction in captured["system_prompt"]
     min_words, max_words = agent._calculate_word_limits(agent.word_count)
+    assert f"Wortkorridor: {min_words}–{max_words}" in prompt_text
     assert f"{min_words}-{max_words}" in captured["system_prompt"]
     assert captured["prompt_type"] == "revision"
 

--- a/wordsmith/prompts_config.json
+++ b/wordsmith/prompts_config.json
@@ -74,7 +74,7 @@
         },
         "revision": {
             "system_prompt": "Du bist Cheflektor:in. Poliere den gelieferten Text für Klarheit, Flow, Terminologie und Rhythmus. Halte Ton, Register und Variante stabil, nutze starke Verben und kennzeichne fehlende Fakten mit Platzhaltern. Gib nur den überarbeiteten Text in Markdown zurück und arbeite ausschließlich mit der übergebenen Fassung.",
-            "prompt": "",
+            "prompt": "Überarbeite den folgenden {text_type} entlang der Nutzerangaben.\nHalte Format, Struktur, Erzählperspektive, Zeitform und Layout exakt bei; füge keine neuen Überschriften, Listen, Fußnoten oder Meta-Hinweise hinzu.\nArbeite ausschließlich mit dem gelieferten Material, ohne Fakten zu erfinden, und kennzeichne Lücken weiterhin mit Platzhaltern.\n\nNutzervorgaben:\n- Zielgruppe: {audience}\n- Tonfall: {tone}\n- Register: {register}\n- Sprachvariante: {variant}\n- Texttyp: {text_type}\n- Quellenmodus: {sources_mode}\n- Zusätzliche Constraints: {constraints}\n- SEO-Keywords: {seo_keywords}\n- Iteration: {iteration}\n- Wortkorridor: {min_words}–{max_words}\n- Zielwortzahl: {target_words}\n\nBriefing:\n{briefing}\n\nText zur Überarbeitung:\n{text}\n",
             "parameters": {
                 "temperature": 0.65,
                 "top_p": 1.0,


### PR DESCRIPTION
## Summary
- add a detailed revision prompt template that references user-provided context
- extend the revision prompt builder and agent to format revision requests with briefing data and constraints
- update tests to cover the new prompt structure and ensure required context values are present

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf9385581083258c2e9f4a1b2da0f2