### PR TITLE
Allow comments in input workflow file

### DIFF
--- a/docs/examples/automatikmodus-input.json
+++ b/docs/examples/automatikmodus-input.json
@@ -18,6 +18,8 @@
   ],
   "include_compliance_note": true,
   "ollama_model": "mistral",
+  // "ollama_base_url": "http://localhost:11434",
+  // "config": "pfade/zu/konfiguration.json",
   "output_dir": "output",
   "logs_dir": "logs"
 }


### PR DESCRIPTION
## Summary
- strip // and /* */ comments from automatikmodus input files before JSON parsing
- document optional `ollama_base_url` and `config` keys in the example settings file as commented lines
- cover the comment handling with a dedicated CLI test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf9be388bc832595c2a55c65ee255b