### PR TITLE
Add DuckDuckGo research when sources are allowed

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -413,6 +413,7 @@ def test_automatikmodus_runs_and_creates_outputs(tmp_path: Path, monkeypatch: py
     assert final_file.read_text(encoding="utf-8").strip() == current_text.strip()
     assert metadata["audience"] == "Vorstand"
     assert metadata["llm_model"] == "llama2"
+    assert metadata["source_research"] == []
     assert compliance["checks"]
     assert not responses
 
@@ -681,3 +682,4 @@ def test_defaults_applied_for_missing_extended_arguments(tmp_path: Path, monkeyp
     assert metadata["audience"] == DEFAULT_AUDIENCE
     assert metadata["register"] == DEFAULT_REGISTER
     assert metadata["variant"] == DEFAULT_VARIANT
+    assert metadata["source_research"] == []

--- a/wordsmith/config.py
+++ b/wordsmith/config.py
@@ -19,6 +19,7 @@ TEMPORARY_OUTPUT_PATTERNS: tuple[str, ...] = (
     "briefing.json",
     "idea.txt",
     "outline.txt",
+    "source_research.json",
     "current_text.txt",
     "text_type_check.txt",
     "text_type_fix.txt",
@@ -69,6 +70,7 @@ class Config:
     token_limit: int = 1024
     system_prompt: Optional[str] = None
     word_count: int = 0
+    source_search_query_count: int = 3
 
     def __post_init__(self) -> None:
         self.output_dir = Path(self.output_dir)
@@ -76,6 +78,8 @@ class Config:
         self.prompt_config_path = Path(self.prompt_config_path)
         self.ensure_directories()
         self._apply_minimum_limits()
+        if self.source_search_query_count < 0:
+            raise ConfigError("`source_search_query_count` darf nicht negativ sein.")
 
     def adjust_for_word_count(self, word_count: int) -> None:
         """Store the desired word count and ensure it is sensible."""
@@ -153,6 +157,11 @@ def _update_config_from_dict(config: Config, data: Dict[str, Any]) -> None:
             if not isinstance(value, dict):
                 raise ConfigError("LLM-Einstellungen müssen ein Objekt sein.")
             config.llm.update(value)
+        elif key == "source_search_query_count":
+            count = int(value)
+            if count < 0:
+                raise ConfigError("`source_search_query_count` darf nicht negativ sein.")
+            config.source_search_query_count = count
         else:
             raise ConfigError(f"Unbekannter Konfigurationsschlüssel: {key}")
 


### PR DESCRIPTION
## Summary
- add configuration support for specifying how many DuckDuckGo queries to issue when external sources are enabled
- trigger DuckDuckGo research from outline sections, persist the collected results, and surface them in metadata and logs
- cover the new behaviour with unit tests for the agent, CLI metadata, and configuration loading

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfa2a4a18c83258359a4eefeffca68