### PR TITLE
Include reflection insights in revision prompts

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -99,6 +99,31 @@ def test_prompt_templates_match_configuration() -> None:
     assert "Iteration: 2" in filled_revision
     assert "Text zur Überarbeitung:\nEntwurf" in filled_revision
 
+    improvement_text = "1. Einleitung schärfen (Absatz 1)"
+    revision_with_guidance = prompts.build_revision_prompt(
+        target_words=500,
+        min_words=450,
+        max_words=550,
+        context=sample_context,
+        improvement_suggestions=improvement_text,
+    )
+    assert prompts.REVISION_REFLECTION_HEADER in revision_with_guidance
+    assert improvement_text in revision_with_guidance
+    if compliance_instruction:
+        revision_with_hint = prompts.build_revision_prompt(
+            include_compliance_hint=True,
+            target_words=500,
+            min_words=450,
+            max_words=550,
+            context=sample_context,
+            improvement_suggestions=improvement_text,
+        )
+        assert revision_with_hint.endswith(compliance_instruction)
+        assert (
+            revision_with_hint.index(prompts.REVISION_REFLECTION_HEADER)
+            < revision_with_hint.rindex(compliance_instruction)
+        )
+
 
 def test_prompt_templates_emphasize_quality_controls() -> None:
     """The curated prompts must retain critical quality and safety guidance."""

--- a/wordsmith/prompts.py
+++ b/wordsmith/prompts.py
@@ -93,6 +93,7 @@ REVISION_SYSTEM_PROMPT: str = ""
 REFLECTION_SYSTEM_PROMPT: str = ""
 FINAL_DRAFT_SYSTEM_PROMPT: str = ""
 COMPLIANCE_HINT_INSTRUCTION: str = ""
+REVISION_REFLECTION_HEADER: str = "Verbesserungsfokus aus letzter Reflexion:"
 
 
 def _read_prompt_config(
@@ -322,6 +323,7 @@ def build_revision_prompt(
     min_words: int,
     max_words: int,
     context: Mapping[str, Any] | None = None,
+    improvement_suggestions: str | None = None,
 ) -> str:
     """Return the revision prompt, optionally with the compliance hint appended."""
 
@@ -341,6 +343,14 @@ def build_revision_prompt(
         )
     else:
         prompt = ""
+
+    suggestions_text = (improvement_suggestions or "").strip()
+    if suggestions_text:
+        suggestions_block = f"{REVISION_REFLECTION_HEADER}\n{suggestions_text}"
+        if prompt:
+            prompt = f"{prompt}\n\n{suggestions_block}"
+        else:
+            prompt = suggestions_block
 
     if not include_compliance_hint:
         return prompt


### PR DESCRIPTION
## Summary
- pass each revision the prioritized improvement list from the previous reflection
- extend the revision prompt builder with a reflection header so suggestions are embedded in the prompt text
- update agent and prompt tests to cover reflection-aware revisions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0d72aad988325bc5a4b466305b465