### PR TITLE
Add option to omit outline headings

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -43,6 +43,7 @@ _CLI_OPTION_MAP: dict[str, str] = {
     "variant": "--variant",
     "constraints": "--constraints",
     "sources_allowed": "--sources-allowed",
+    "include_outline_headings": "--outline-headings",
     "seo_keywords": "--seo-keywords",
     "include_compliance_note": "--compliance-hint",
     "config": "--config",
@@ -306,6 +307,9 @@ def _build_setting_tokens(key: str, value: object) -> List[str]:
     if key == "sources_allowed":
         allowed = _coerce_bool_from_input(key, value)
         return [option, "true" if allowed else "false"]
+    if key == "include_outline_headings":
+        include = _coerce_bool_from_input(key, value)
+        return [option, "true" if include else "false"]
     if key == "seo_keywords":
         formatted = _format_keywords_argument(value)
         return [option, formatted]
@@ -445,6 +449,13 @@ def _build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_SOURCES_ALLOWED,
         dest="sources_allowed",
         help="Ob Quellenangaben erlaubt sind (ja/nein).",
+    )
+    automatik_parser.add_argument(
+        "--outline-headings",
+        type=_parse_bool,
+        default=True,
+        dest="include_outline_headings",
+        help="Ob die Outline-Überschriften im finalen Text stehen bleiben (ja/nein).",
     )
     automatik_parser.add_argument(
         "--seo-keywords",
@@ -624,6 +635,7 @@ def _run_automatikmodus(args: argparse.Namespace) -> int:
         sources_allowed=args.sources_allowed,
         seo_keywords=args.seo_keywords,
         include_compliance_note=args.include_compliance_note,
+        include_outline_headings=args.include_outline_headings,
         progress_callback=progress_printer,
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -207,6 +207,7 @@ def test_input_file_supports_commented_lines(
   \"sources_allowed\": true,
   \"seo_keywords\": [\"Alpha\"],
   \"include_compliance_note\": false,
+  \"include_outline_headings\": false,
   \"ollama_model\": \"mistral\",
   /* \"ollama_base_url\": \"http://localhost:11434\", */
   \"output_dir\": \"output\",
@@ -240,6 +241,7 @@ def test_input_file_supports_commented_lines(
     assert config.llm_provider == "openai"
     assert captured_kwargs["sources_allowed"] is True
     assert captured_kwargs["seo_keywords"] == ["Alpha"]
+    assert captured_kwargs["include_outline_headings"] is False
 
 
 def test_input_file_reports_errors(


### PR DESCRIPTION
## Summary
- add a configurable `include_outline_headings` flag to the writer agent, CLI and metadata
- drop generated outline headings when the flag is disabled and inform section prompts via style guidelines
- extend CLI and agent tests to cover the new option and metadata field

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1453aa9f88325ac077b2de2a910af