### PR TITLE
Filter comment lines from iteration outputs

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -292,6 +292,9 @@ def test_agent_generates_outputs_with_llm(tmp_path: Path, monkeypatch: pytest.Mo
     idea_output = (config.output_dir / "idea.txt").read_text(encoding="utf-8").strip()
     outline_output = (config.output_dir / "outline.txt").read_text(encoding="utf-8").strip()
     current_text = (config.output_dir / "current_text.txt").read_text(encoding="utf-8")
+    iteration_output = (
+        config.output_dir / "iteration_02.txt"
+    ).read_text(encoding="utf-8")
     reflection_output = (
         config.output_dir / "reflection_02.txt"
     ).read_text(encoding="utf-8").strip()
@@ -306,6 +309,7 @@ def test_agent_generates_outputs_with_llm(tmp_path: Path, monkeypatch: pytest.Mo
 
     assert "[ENTFERNT: vertrauliche]" in final_output
     assert "[ENTFERNT: vertrauliche]" in current_text
+    assert all(not line.startswith("#") for line in iteration_output.splitlines())
     assert idea_output == idea_text
     assert "Strategiepfad" in outline_output
     assert "Einleitung präzisieren" in reflection_output

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -1542,7 +1542,11 @@ class WriterAgent:
         )
 
     def _write_text(self, path: Path, text: str) -> None:
-        path.write_text(text.strip() + "\n", encoding="utf-8")
+        cleaned_text = text.strip()
+        if path.name.startswith("iteration_") and path.suffix == ".txt":
+            lines = [line for line in cleaned_text.splitlines() if not line.startswith("#")]
+            cleaned_text = "\n".join(lines).strip()
+        path.write_text(cleaned_text + "\n", encoding="utf-8")
 
     def _write_final_output(self, text: str) -> Path:
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")


### PR DESCRIPTION
## Summary
- skip lines starting with `#` when persisting `iteration_*.txt` outputs so comment prefixed headings are dropped
- extend the writer agent integration test to ensure iteration files no longer contain these comment lines

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d232fee040832589e8b1e7a6070165