### PR TITLE
Handle streamed Ollama responses when assembling text

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -21,6 +21,20 @@ class _DummyResponse:
         return json.dumps({"response": "Antwort"}).encode("utf-8")
 
 
+class _StreamingResponse:
+    def __init__(self, payloads):
+        self._data = "\n".join(json.dumps(payload) for payload in payloads).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._data
+
+
 def test_generate_text_uses_configured_timeout(monkeypatch):
     captured = {}
 
@@ -81,3 +95,38 @@ def test_generate_text_strips_context_from_raw_payload(monkeypatch):
     assert "context" not in result.raw
     assert result.raw["context_token_count"] == 3
     assert result.raw["response"] == "Antwort"
+
+
+def test_generate_text_handles_streaming_payload(monkeypatch):
+    fragments = [
+        {"response": "Erster Teil ", "done": False},
+        {"response": "und zweiter Abschnitt.", "done": False},
+        {
+            "response": "",
+            "done": True,
+            "context": [1, 2, 3],
+            "prompt_eval_count": 12,
+            "eval_count": 24,
+        },
+    ]
+
+    def fake_urlopen(request, timeout):
+        return _StreamingResponse(fragments)
+
+    monkeypatch.setattr(llm.urllib.request, "urlopen", fake_urlopen)
+
+    result = llm.generate_text(
+        provider="ollama",
+        model="mixtral",
+        prompt="Hallo",
+        system_prompt="System",
+        parameters=LLMParameters(),
+    )
+
+    assert result.text == "Erster Teil und zweiter Abschnitt."
+    assert result.raw["context_token_count"] == 3
+    assert result.raw.get("response") == ""
+    assert result.raw.get("response_fragments") == [
+        "Erster Teil ",
+        "und zweiter Abschnitt.",
+    ]


### PR DESCRIPTION
## Summary
- collect text fragments from Ollama responses so streamed payloads return a complete draft
- extend the LLM tests with a regression covering multi-chunk responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d30a8993708325b264904fedcef80e