### PR TITLE
Simplify final draft prompt builder

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -155,8 +155,53 @@ def test_prompt_templates_emphasize_quality_controls() -> None:
     assert "Poliere" in prompts.REVISION_SYSTEM_PROMPT
     assert "Markdown" in prompts.REVISION_SYSTEM_PROMPT
     assert "Fassung" in prompts.REVISION_SYSTEM_PROMPT
-    assert "packenden Einstieg" in prompts.FINAL_DRAFT_PROMPT
+    final_template = prompts.FINAL_DRAFT_PROMPT
+    assert "Titel: {title}" in final_template
+    assert "Outline:\n{outline}" in final_template
+    assert "Stil: {style}" in final_template
+    assert "Zielwortzahl: {target_words}" in final_template
+    assert "{format_instruction}" in final_template
     assert "konkrete Handlungen" in prompts.REFLECTION_PROMPT
+
+
+def test_build_final_draft_prompt_removes_meta_guidance() -> None:
+    """The final draft prompt collapses to the requested minimalist form."""
+
+    outline = (
+        "1. Auftakt (Rolle: Hook, Budget: 200 Wörter) -> Setup\n"
+        "    - Fokus: Spannung\n"
+        "2. Finale (Rolle: Abschluss, Budget: 180 Wörter)"
+    )
+    prompt_text = prompts.buildFinalDraftPrompt(
+        title="Erfolgsgeschichte",
+        outline=outline,
+        style="Ton: inspirierend; Register: Du",
+        targetWords=500,
+    )
+
+    assert prompt_text.startswith("Titel: Erfolgsgeschichte")
+    assert "Outline:\n1. Auftakt" in prompt_text
+    assert "Rolle" not in prompt_text
+    assert "Budget" not in prompt_text
+    assert "->" not in prompt_text
+    assert "Stil: Ton: inspirierend; Register: Du" in prompt_text
+    assert "Zielwortzahl: 500" in prompt_text
+    assert prompt_text.endswith("Gib nur den Fließtext zurück.")
+
+
+def test_build_final_draft_prompt_accepts_custom_output_format() -> None:
+    """Custom output instructions can replace the default text-only hint."""
+
+    prompt_text = prompts.buildFinalDraftPrompt(
+        title="Whitepaper",
+        outline="1. Einleitung",
+        style="Ton: sachlich",
+        targetWords=1200,
+        output_format="Bitte als Markdown mit Überschriften liefern.",
+    )
+
+    assert prompt_text.endswith("Bitte als Markdown mit Überschriften liefern.")
+    assert "Gib nur den Fließtext zurück." not in prompt_text
 
 
 def test_prompt_configuration_has_no_merge_markers() -> None:

--- a/wordsmith/prompts_config.json
+++ b/wordsmith/prompts_config.json
@@ -94,7 +94,7 @@
         },
         "final_draft": {
             "system_prompt": "Du bist eine erfahrene Hauptautor:in. Du orchestrierst alle Vorgaben zu einem überzeugenden, konsistenten finalen Text, balancierst Dramaturgie, Wortbudgets und sprachliche Wirkung.",
-            "prompt": "Schreibe den finalen {text_type} zum Thema \"{title}\" mit etwa {word_count} Wörtern (±3 %).\nArbeite strikt mit den folgenden Informationen und Regeln.\n\nBriefing:\n{briefing_json}\n\nGliederung:\n{outline}\n\nKernaussagen aus der Idee:\n{idea_bullets}\n\nRegeln:\n- Tonfall: {tone}\n- Register: {register}\n- Sprachvariante: {variant_hint}\n- Quellenmodus: {sources_mode}\n- Zusätzliche Constraints: {constraints}\n- SEO-Keywords: {seo_keywords}\n- Wenn die Outline Überschriften vorsieht, übernimm sie exakt gemäß `## {{nummer}}. {{Titel}}`; andernfalls respektiere die Segmentierung durch passende Trenner oder Übergänge und halte die Wortbudgets pro Abschnitt grob ein.\n- Erfinde keine neuen Fakten; nutze Platzhalter wie [KLÄREN:], [KENNZAHL], [QUELLE], [DATUM].\n- Sorge für einen packenden Einstieg, stimmige Übergänge und einen Abschluss, der die beabsichtigte Wirkung erzielt (z. B. Auflösung, CTA, Fazit).\n- Verwende Keywords organisch, ohne den Charakter des {text_type} zu stören, und optimiere Lesbarkeit sowie Rhythmus im Rahmen des Formats.\nGib ausschließlich den ausgearbeiteten Text in Markdown zurück.\n",
+            "prompt": "Titel: {title}\n\nOutline:\n{outline}\n\nStil: {style}\nZielwortzahl: {target_words}\n{format_instruction}",
             "parameters": {
                 "temperature": 0.68,
                 "top_p": 1.0,


### PR DESCRIPTION
## Summary
- replace the final draft template with a minimalist format and provide a helper that appends the proper output instruction
- update the writer agent to compose a final-style summary, clean the outline, and build the final-draft prompt via the helper
- extend prompt tests to cover the new final-draft builder behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3dd085c9c83258a978566ec25cbd5