### PR TITLE
Respect configurable sampling limits and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,20 @@ entsprechen den Attributen des `Config`-Dataclasses, u. a.:
 * `prompt_config_path` – Pfad zur JSON-Datei mit den Prompt-Templates
 * `llm` (Objekt mit Parametern wie `temperature`, `top_p`, `seed`)
 
+Ohne weitere Anpassung generiert WordSmith bis zu 900 Tokens pro Aufruf
+(`llm.num_predict`, alias `llm.max_tokens`), wobei der Wert vollständig
+konfigurierbar bleibt.
+
 `Config.adjust_for_word_count(word_count)` setzt den gewünschten Umfang,
 skalieren `context_length` auf mindestens `word_count * 4` (mindestens
 8192) und `token_limit` auf mindestens `word_count * 1,9` (ebenfalls
 mindestens 8192). Gleichzeitig werden deterministische LLM-Parameter
-gesetzt (`temperature=0.7`, `top_p=1.0`, `presence_penalty=0.05`,
-`frequency_penalty=0.05`, Seed 42); falls verfügbar, wird `num_predict`
-auf das Token-Limit angepasst. `ensure_directories()` erstellt Output- und
-Log-Ordner, `cleanup_temporary_outputs()` entfernt Artefakte früherer
-Läufe.
+für `presence_penalty`, `frequency_penalty` und die Seed-Einstellung
+vereinheitlicht; `temperature` und `top_p` behalten die in der
+Konfiguration definierten Werte. Falls verfügbar, wird `num_predict`
+auf das Token-Limit angepasst, sofern kein eigener Wert konfiguriert
+wurde. `ensure_directories()` erstellt Output- und Log-Ordner,
+`cleanup_temporary_outputs()` entfernt Artefakte früherer Läufe.
 
 Die mitgelieferte Datei `wordsmith/prompts_config.json` enthält alle
 Prompt-Templates. Wird ein eigener Satz benötigt, kann `prompt_config_path`

--- a/docs/automatikmodus.md
+++ b/docs/automatikmodus.md
@@ -139,9 +139,12 @@ zusätzlich die Outline, verwendeten Prompts, Parameter sowie Telemetrie
 
 `Config.adjust_for_word_count()` stellt sicher, dass Kontextlänge und
 Tokenlimit proportional zum Zielumfang wachsen (mindestens 8192 Tokens).
-Zudem werden deterministische Parameter gesetzt (`temperature=0.7`,
-`top_p=1.0`, `presence_penalty=0.05`, `frequency_penalty=0.05`, Seed 42).
-Falls verfügbar, wird `num_predict` auf das Tokenlimit gesetzt.
+Zudem werden deterministische Parameter vereinheitlicht
+(`presence_penalty=0.05`, `frequency_penalty=0.05`, Seed 42), während
+`temperature` und `top_p` die konfigurierten Werte behalten. Falls
+verfügbar, wird `num_predict` auf das Tokenlimit gesetzt, sofern kein
+eigener Wert vorgegeben ist. Ohne explizite Vorgabe liegt das Limit bei
+900 Tokens pro LLM-Aufruf.
 
 `WriterAgent._call_llm_stage()` lehnt Aufrufe ab, deren geschätzter
 Tokenbedarf 85 % des Limits überschreitet, und protokolliert Fehler oder

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -130,3 +130,19 @@ def test_generate_text_handles_streaming_payload(monkeypatch):
         "Erster Teil ",
         "und zweiter Abschnitt.",
     ]
+
+
+def test_prepare_options_include_stop_and_num_predict_defaults() -> None:
+    params = LLMParameters()
+
+    options = llm._prepare_options(params)
+
+    assert options["num_predict"] == 900
+    assert options["stop"] == []
+
+    params.update({"num_predict": 256, "stop": ["ENDE"]})
+
+    updated = llm._prepare_options(params)
+
+    assert updated["num_predict"] == 256
+    assert updated["stop"] == ["ENDE"]

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -1821,6 +1821,8 @@ class WriterAgent:
             base.num_predict = getattr(self.config.llm, "num_predict", None)
         overrides = prompts.STAGE_PROMPT_PARAMETERS.get(prompt_type, {})
         for key, value in overrides.items():
+            if key in {"temperature", "top_p"} and self.config.llm.has_override(key):
+                continue
             if hasattr(base, key):
                 setattr(base, key, value)
         return base

--- a/wordsmith/llm.py
+++ b/wordsmith/llm.py
@@ -32,6 +32,18 @@ def _prepare_options(parameters: LLMParameters) -> Dict[str, Any]:
         options["seed"] = parameters.seed
     if getattr(parameters, "num_predict", None) is not None:
         options["num_predict"] = int(parameters.num_predict)
+    stop_sequences = getattr(parameters, "stop", ())
+    if stop_sequences is None:
+        options["stop"] = []
+    elif isinstance(stop_sequences, str):
+        cleaned = stop_sequences.strip()
+        options["stop"] = [cleaned] if cleaned else []
+    else:
+        options["stop"] = [
+            str(entry).strip()
+            for entry in stop_sequences
+            if str(entry).strip()
+        ]
     return options
 
 


### PR DESCRIPTION
## Summary
- default Ollama requests to 900 tokens with empty stop sequences and track LLM parameter overrides
- honour configured temperature/top_p values in the agent while allowing prompt defaults when no override is set
- document the new behaviour and extend the test suite for max token aliases and stop normalisation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3df6adbcc83258da5a412b8a2954c