### PR TITLE
Expose LLM response when briefing JSON parsing fails

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -643,6 +643,15 @@ def _run_automatikmodus(args: argparse.Namespace) -> int:
         final_text = agent.run()
     except WriterAgentError as exc:
         print(f"Automatikmodus konnte nicht abgeschlossen werden: {exc}", file=sys.stderr)
+        raw_text = getattr(exc, "context", {}).get("raw_text") if hasattr(exc, "context") else None
+        if raw_text:
+            raw_text_str = str(raw_text).rstrip()
+            if raw_text_str:
+                print(
+                    "LLM-Antwort (konnte nicht als JSON interpretiert werden):",
+                    file=sys.stderr,
+                )
+                print(raw_text_str, file=sys.stderr)
         _print_runtime(agent.runtime_seconds, stream=sys.stderr)
         return 1
 


### PR DESCRIPTION
## Summary
- show the raw LLM response in the recorded error message when briefing JSON parsing fails
- print the raw LLM response to stderr in the CLI when the briefing JSON cannot be parsed
- add regression tests covering the new agent event formatting and CLI output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3ecebf1cc832580a0fff988347447