### PR TITLE
Handle truncated LLM briefing JSON

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -192,6 +192,35 @@ def test_load_json_object_handles_invalid_escape_sequences() -> None:
     assert result["key_terms"] == ["KI"]
 
 
+def test_load_json_object_recovers_from_missing_closing_brace() -> None:
+    truncated = (
+        "{\n"
+        "  \"goal\": \"Test\",\n"
+        "  \"key_terms\": [\"KI\", \"keller\"],\n"
+        "  \"messages\": [\n"
+        "    \"Hinweis eins\",\n"
+        "    \"Hinweis zwei\"\n"
+        "  ],\n"
+        "  \"seo_keywords\": [\n"
+        "    \"\",\n"
+        "    \"\"\n"
+        "  ]\n"
+    )
+
+    result = _load_json_object(truncated)
+
+    assert result["goal"] == "Test"
+    assert result["seo_keywords"] == ["", ""]
+
+
+def test_load_json_object_recovers_from_missing_closing_brackets() -> None:
+    truncated = '{"goal": "Test", "messages": ["A", "B"'
+
+    result = _load_json_object(truncated)
+
+    assert result["messages"] == ["A", "B"]
+
+
 def test_agent_requires_llm_configuration(tmp_path: Path) -> None:
     config = _build_config(tmp_path, 200)
 


### PR DESCRIPTION
## Summary
- add a balancing helper to recover from unterminated JSON objects in LLM briefing responses
- reuse the helper in the parser so truncated replies are parsed before falling back to literal evaluation
- extend agent tests to cover JSON strings missing closing braces or brackets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3ef9632a08325be1d924082b413e0