### PR TITLE
Fix combined draft data recorded after section assembly

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -299,7 +299,8 @@ def test_generate_draft_records_section_outputs(tmp_path: Path, monkeypatch: pyt
         agent._format_artifact_path(agent._stage_output_dir / "002_section_02_llm.txt"),
     ]
     assert agent._llm_generation["section_outputs"] == expected_paths
-    assert agent._llm_generation["combined_output"] == "current_text.txt"
+    assert agent._llm_generation["combined_output"] == draft
+    assert agent._llm_generation["combined_output_path"] == "current_text.txt"
 def test_load_json_object_handles_invalid_escape_sequences() -> None:
     malformed = '{"goal": "Test", "key\\_terms": ["KI"], "messages": ["Hinweis"]}'
 

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -1232,7 +1232,8 @@ class WriterAgent:
             "sections": section_summaries,
             "response_preview": final_draft[:400],
             "section_outputs": section_artifacts,
-            "combined_output": self._format_artifact_path(
+            "combined_output": final_draft,
+            "combined_output_path": self._format_artifact_path(
                 self.output_dir / "current_text.txt"
             ),
         }


### PR DESCRIPTION
## Summary
- store the fully assembled draft text in `llm_generation["combined_output"]`
- keep tracking the output file location separately via `combined_output_path`
- update the section compilation test to cover the new metadata structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4c75aad608325884c9cd4499abf13