### PR TITLE
Ensure Ollama requests start new conversations

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -56,6 +56,26 @@ def test_generate_text_uses_configured_timeout(monkeypatch):
     assert captured["timeout"] == OLLAMA_TIMEOUT_SECONDS
 
 
+def test_generate_text_starts_with_empty_context(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["payload"] = json.loads(request.data.decode("utf-8"))
+        return _DummyResponse()
+
+    monkeypatch.setattr(llm.urllib.request, "urlopen", fake_urlopen)
+
+    llm.generate_text(
+        provider="ollama",
+        model="mixtral",
+        prompt="Hallo",
+        system_prompt="System",
+        parameters=LLMParameters(),
+    )
+
+    assert captured["payload"].get("context") == []
+
+
 def test_generate_text_strips_context_from_raw_payload(monkeypatch):
     payload = {
         "response": "Antwort",

--- a/wordsmith/llm.py
+++ b/wordsmith/llm.py
@@ -183,6 +183,9 @@ def _generate_with_ollama(
         "prompt": prompt,
         "system": system_prompt,
         "stream": False,
+        # Start every request with an empty context to avoid reusing previous
+        # conversations that Ollama might keep around implicitly.
+        "context": [],
         "options": _prepare_options(parameters),
     }
     data = json.dumps(payload).encode("utf-8")


### PR DESCRIPTION
## Summary
- force Ollama generate calls to include an empty context so each request starts fresh
- add regression test verifying the request payload contains an empty context list

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4ef1dc62c83258c13850f45700f47