### PR TITLE
Fix false placeholder detection for literal braces

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -226,3 +226,13 @@ def test_generate_text_hard_fails_on_unresolved_placeholders(
         assert detail in message
     assert payload_hash in message
     assert any(payload_hash in record.message for record in caplog.records)
+
+
+def test_sanitise_payload_allows_braces_in_literal_text() -> None:
+    payload = {
+        "prompt": 'Gib ein JSON-Fragment {"anfang": "\"", "ende": "\""}.',
+        "system": "System",
+    }
+
+    # Must not raise despite braces that are part of literal content.
+    llm._sanitise_payload(payload)

--- a/wordsmith/llm.py
+++ b/wordsmith/llm.py
@@ -14,6 +14,7 @@ from .config import LLMParameters, OLLAMA_TIMEOUT_SECONDS
 
 _LOGGER = logging.getLogger(__name__)
 _PLACEHOLDER_PATTERN = re.compile(r"(?<!{){([^{}]+)}(?!})")
+_PLACEHOLDER_NAME_PATTERN = re.compile(r"[A-Za-z0-9_.-]+$")
 
 
 @dataclass
@@ -44,7 +45,7 @@ def _sanitise_payload(payload: Mapping[str, Any]) -> None:
         if isinstance(value, str):
             for match in _PLACEHOLDER_PATTERN.finditer(value):
                 placeholder = match.group(1).strip()
-                if placeholder:
+                if placeholder and _PLACEHOLDER_NAME_PATTERN.fullmatch(placeholder):
                     unresolved.append((path or "<root>", placeholder))
             return
         if isinstance(value, Mapping):


### PR DESCRIPTION
## Summary
- restrict unresolved placeholder detection to identifiers matching `[A-Za-z0-9_.-]+`
- add regression test ensuring literal JSON braces in prompts are allowed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4f44fe9308325a17769bef3fd427b