### PR TITLE
Clarify revision prompts to output only revised text

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -153,6 +153,7 @@ def test_prompt_templates_emphasize_quality_controls() -> None:
     assert "Überarbeite den folgenden" in revision_template
     assert "Halte Format" in revision_template
     assert "dichte Übergänge" in revision_template
+    assert "WICHTIG: Gib ausschließlich den überarbeiteten Text zurück" in revision_template
     assert "Poliere" in prompts.REVISION_SYSTEM_PROMPT
     assert "Markdown" in prompts.REVISION_SYSTEM_PROMPT
     assert "Fassung" in prompts.REVISION_SYSTEM_PROMPT
@@ -163,6 +164,10 @@ def test_prompt_templates_emphasize_quality_controls() -> None:
     assert "Zielwortzahl: {target_words}" in final_template
     assert "{format_instruction}" in final_template
     assert "konkrete Handlungen" in prompts.REFLECTION_PROMPT
+    assert (
+        "WICHTIG: Gib ausschließlich den aktualisierten Text zurück"
+        in prompts.TEXT_TYPE_FIX_PROMPT
+    )
 
 
 def test_format_prompt_preserves_double_braced_tokens() -> None:

--- a/wordsmith/prompts_config.json
+++ b/wordsmith/prompts_config.json
@@ -64,7 +64,7 @@
         },
         "text_type_fix": {
             "system_prompt": "Du bist eine präzise Textchirurg:in. Du korrigierst zielgerichtet, bewahrst Stil, Struktur und Wortbudgets und arbeitest nur die genannten Abweichungen ab.",
-            "prompt": "Korrigiere nur die genannten Abweichungen minimal-invasiv, ohne Faktenzuwachs.\nVorgehen:\n1. Übernimm ausschließlich notwendige Änderungen direkt im Text (keine Anmerkungen oder Hervorhebungen).\n2. Bewahre vorhandene Formatierung, Abschnittsüberschriften oder andere Strukturmarker sowie Reihenfolge und Wortbudgets soweit möglich.\n3. Nutze vorhandene Platzhalter weiter oder markiere neue Informationslücken mit `[KLÄREN: …]`.\n4. Lies nach der Überarbeitung quer, um Konsistenz, Übergänge und Terminologie zu sichern.\nGib nur den aktualisierten Text zurück.\n",
+            "prompt": "Korrigiere nur die genannten Abweichungen minimal-invasiv, ohne Faktenzuwachs.\nVorgehen:\n1. Übernimm ausschließlich notwendige Änderungen direkt im Text (keine Anmerkungen oder Hervorhebungen).\n2. Bewahre vorhandene Formatierung, Abschnittsüberschriften oder andere Strukturmarker sowie Reihenfolge und Wortbudgets soweit möglich.\n3. Nutze vorhandene Platzhalter weiter oder markiere neue Informationslücken mit `[KLÄREN: …]`.\n4. Lies nach der Überarbeitung quer, um Konsistenz, Übergänge und Terminologie zu sichern.\nWICHTIG: Gib ausschließlich den aktualisierten Text zurück und starte die Ausgabe ohne zusätzliche Erläuterungen, Listen oder Wiederholungen dieser Anweisungen.\n",
             "parameters": {
                 "temperature": 0.6,
                 "top_p": 1.0,
@@ -74,11 +74,11 @@
         },
         "revision": {
             "system_prompt": "Du bist Cheflektor:in. Poliere die gelieferte Fassung für Klarheit, Flow, Terminologie und Rhythmus, halte Ton, Register und Variante stabil, nutze starke Verben und kennzeichne fehlende Fakten mit Platzhaltern. Gib nur den überarbeiteten Text in Markdown zurück und arbeite ausschließlich mit der übergebenen Fassung.",
-            "prompt": "Überarbeite den folgenden {text_type} entlang der Nutzerangaben.\nHalte Format, Struktur, Erzählperspektive, Zeitform und Layout exakt bei; füge keine neuen Überschriften, Listen, Fußnoten oder Meta-Hinweise hinzu.\nArbeite ausschließlich mit dem gelieferten Material, ohne Fakten zu erfinden, kennzeichne Lücken weiterhin mit Platzhaltern und sorge für dichte Übergänge sowie konsistente Terminologie.\nFalls unten ein Block \"Verbesserungsfokus aus letzter Reflexion\" steht, behandle jeden Punkt als verbindlichen Arbeitsauftrag: arbeite die Hinweise nacheinander ab, integriere ihre Wirkung präzise im betroffenen Abschnitt und stelle sicher, dass das Ergebnis jeden Auftrag sichtbar erfüllt.\n\nNutzervorgaben:\n- Zielgruppe: {audience}\n- Tonfall: {tone}\n- Register: {register}\n- Sprachvariante: {variant}\n- Texttyp: {text_type}\n- Quellenmodus: {sources_mode}\n- Zusätzliche Constraints: {constraints}\n- SEO-Keywords: {seo_keywords}\n- Iteration: {iteration}\n- Wortkorridor: {min_words}–{max_words}\n- Zielwortzahl: {target_words}\n\nBriefing:\n{briefing}\n\nText zur Überarbeitung:\n{text}\n",
-            "parameters": {
-                "temperature": 0.65,
-                "top_p": 1.0,
-                "presence_penalty": 0.05,
+            "prompt": "Überarbeite den folgenden {text_type} entlang der Nutzerangaben.\nHalte Format, Struktur, Erzählperspektive, Zeitform und Layout exakt bei; füge keine neuen Überschriften, Listen, Fußnoten oder Meta-Hinweise hinzu.\nArbeite ausschließlich mit dem gelieferten Material, ohne Fakten zu erfinden, kennzeichne Lücken weiterhin mit Platzhaltern und sorge für dichte Übergänge sowie konsistente Terminologie.\nFalls unten ein Block \"Verbesserungsfokus aus letzter Reflexion\" steht, behandle jeden Punkt als verbindlichen Arbeitsauftrag: arbeite die Hinweise nacheinander ab, integriere ihre Wirkung präzise im betroffenen Abschnitt und stelle sicher, dass das Ergebnis jeden Auftrag sichtbar erfüllt.\nWICHTIG: Gib ausschließlich den überarbeiteten Text zurück, beginne die Ausgabe sofort mit dem ersten Zeichen des Textes und wiederhole keine Elemente dieses Prompts (z. B. Listen, Überschriften, Iterationshinweise).\n\nNutzervorgaben:\n- Zielgruppe: {audience}\n- Tonfall: {tone}\n- Register: {register}\n- Sprachvariante: {variant}\n- Texttyp: {text_type}\n- Quellenmodus: {sources_mode}\n- Zusätzliche Constraints: {constraints}\n- SEO-Keywords: {seo_keywords}\n- Iteration: {iteration}\n- Wortkorridor: {min_words}–{max_words}\n- Zielwortzahl: {target_words}\n\nBriefing:\n{briefing}\n\nText zur Überarbeitung:\n{text}\n",
+        "parameters": {
+            "temperature": 0.65,
+            "top_p": 1.0,
+            "presence_penalty": 0.05,
                 "frequency_penalty": 0.05
             }
         },


### PR DESCRIPTION
## Summary
- reinforce the revision and text-type-fix prompts so LLMs return only the edited text instead of echoing instructions
- add tests asserting the strengthened guidance is present in the prompt templates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d524ad0ddc8325854c19c00ad44f22