### PR TITLE
Relax placeholder validation for literal braces in prompts

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -236,3 +236,14 @@ def test_sanitise_payload_allows_braces_in_literal_text() -> None:
 
     # Must not raise despite braces that are part of literal content.
     llm._sanitise_payload(payload)
+
+
+def test_sanitise_payload_ignores_braces_with_names() -> None:
+    payload = {
+        "prompt": "Vorlage enthält {Name} und {Titel} als Beispieltext.",
+        "system": "System",
+    }
+
+    # Uppercase markers originate from Texteingaben und dürfen den Lauf
+    # nicht blockieren.
+    llm._sanitise_payload(payload)

--- a/wordsmith/llm.py
+++ b/wordsmith/llm.py
@@ -14,7 +14,18 @@ from .config import LLMParameters, OLLAMA_TIMEOUT_SECONDS
 
 _LOGGER = logging.getLogger(__name__)
 _PLACEHOLDER_PATTERN = re.compile(r"(?<!{){([^{}]+)}(?!})")
-_PLACEHOLDER_NAME_PATTERN = re.compile(r"[A-Za-z0-9_.-]+$")
+# Only treat lowercase placeholder tokens as unresolved template fields.
+#
+# Promptvorlagen nutzen konsequent ``snake_case``-Platzhalter (z. B.
+# ``{target_words}``). Anwendertexte oder LLM-Antworten können jedoch
+# geschweifte Klammern mit Eigennamen wie ``{Name}`` enthalten. Die
+# ursprüngliche Prüfung hat solche Inhalte fälschlich als nicht
+# ersetzte Platzhalter interpretiert und dadurch weitere Iterationen
+# blockiert. Wir beschränken den regulären Ausdruck deshalb auf
+# Kleinbuchstaben sowie die bekannten Trenner. Dadurch bleibt die
+# Validierung für reale Prompt-Platzhalter bestehen, während reguläre
+# Texte mit ``{Name}`` oder ``{Titel}`` nicht mehr beanstandet werden.
+_PLACEHOLDER_NAME_PATTERN = re.compile(r"[a-z0-9_.-]+$")
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- restrict the placeholder validation regex to lowercase snake_case tokens so literal braces like `{Name}` no longer raise errors
- add a regression test covering prompts that contain capitalised brace markers from user text

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d52a3df5bc8325816784d66310049e