### PR TITLE
Prevent section truncation on plain text title prefixes

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1422,3 +1422,71 @@ def test_run_compliance_keeps_note_when_enabled(tmp_path: Path) -> None:
     last_entry = agent._compliance_audit[-1]
     assert last_entry["compliance_note"] is True
     assert last_entry["compliance_note_text"] == "[COMPLIANCE-HINWEIS: Quellen prüfen.]"
+
+
+def test_truncate_following_sections_ignores_plain_title_prefix(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, 200)
+    agent = WriterAgent(
+        topic="Test",
+        word_count=200,
+        steps=[],
+        iterations=0,
+        config=config,
+        content="",
+        text_type="Artikel",
+        audience="Leser:innen",
+        tone="neutral",
+        register="Sie",
+        variant="DE-DE",
+        constraints="",
+        sources_allowed=False,
+    )
+
+    text = "Einleitung mit Beispielen.\n\nNutzen entstehen durch gemeinsame Arbeit."
+    remaining = [
+        OutlineSection(
+            number="2",
+            title="Nutzen",
+            role="Analyse",
+            budget=100,
+            deliverable="Ergebnisse darstellen",
+        )
+    ]
+
+    result = agent._truncate_following_sections(text, remaining)
+
+    assert result == text
+
+
+def test_truncate_following_sections_detects_heading(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, 200)
+    agent = WriterAgent(
+        topic="Test",
+        word_count=200,
+        steps=[],
+        iterations=0,
+        config=config,
+        content="",
+        text_type="Artikel",
+        audience="Leser:innen",
+        tone="neutral",
+        register="Sie",
+        variant="DE-DE",
+        constraints="",
+        sources_allowed=False,
+    )
+
+    text = "Einleitung mit Beispielen.\n\n## Nutzen\nWeitere Details folgen."
+    remaining = [
+        OutlineSection(
+            number="2",
+            title="Nutzen",
+            role="Analyse",
+            budget=100,
+            deliverable="Ergebnisse darstellen",
+        )
+    ]
+
+    result = agent._truncate_following_sections(text, remaining)
+
+    assert result == "Einleitung mit Beispielen."

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -1410,9 +1410,6 @@ class WriterAgent:
             patterns.append(
                 re.compile(rf"^\s*#{{1,6}}\s*{escaped_title}\b", re.IGNORECASE | re.MULTILINE)
             )
-            patterns.append(
-                re.compile(rf"^\s*{escaped_title}\b", re.IGNORECASE | re.MULTILINE)
-            )
         return tuple(patterns)
 
     def _calculate_word_limits(self, budget: int) -> tuple[int, int]:


### PR DESCRIPTION
## Summary
- update section heading detection to ignore plain text lines that only repeat the next title
- add regression tests covering plain-title paragraphs and markdown headings during truncation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7ddfd4b388325ac426acdac2fc4e9