### PR TITLE
Propagate generation limits to stage parameters

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1287,6 +1287,33 @@ def test_revision_prompt_includes_reflection_suggestions(
     assert captured_prompt["prompt_type"] == "revision"
 
 
+def test_stage_parameters_use_configured_generation_limits(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, 400)
+    config.llm.num_predict = 1234
+    config.llm.stop = ("<<END>>",)
+
+    agent = WriterAgent(
+        topic="Parameterkopie",
+        word_count=400,
+        steps=[],
+        iterations=0,
+        config=config,
+        content="",
+        text_type="Fachartikel",
+        audience="Profis",
+        tone="präzise",
+        register="Sie",
+        variant="DE-DE",
+        constraints="",
+        sources_allowed=False,
+    )
+
+    parameters = agent._build_stage_parameters("section")
+
+    assert parameters.num_predict == config.llm.num_predict
+    assert parameters.stop == config.llm.stop
+
+
 def test_call_llm_stage_enforces_token_reserve(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -2015,6 +2015,8 @@ class WriterAgent:
             presence_penalty=self.config.llm.presence_penalty,
             frequency_penalty=self.config.llm.frequency_penalty,
             seed=self.config.llm.seed,
+            num_predict=getattr(self.config.llm, "num_predict", None),
+            stop=getattr(self.config.llm, "stop", ()),
         )
         if hasattr(base, "num_predict"):
             base.num_predict = getattr(self.config.llm, "num_predict", None)


### PR DESCRIPTION
## Summary
- ensure stage-level LLM parameters inherit num_predict and stop from the active configuration
- add a regression test covering propagation of generation limits to stage parameters

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d80dae70e883258c71ddde6ff96b20