### PR TITLE
Enhance reflection prompt to flag word count shortfall

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -168,6 +168,9 @@ def test_prompt_templates_emphasize_quality_controls() -> None:
     assert "Zielwortzahl: {target_words}" in final_template
     assert "{format_instruction}" in final_template
     assert "konkrete Handlungen" in prompts.REFLECTION_PROMPT
+    assert "Zielwortzahl" in prompts.REFLECTION_PROMPT
+    assert "{current_words}" in prompts.REFLECTION_PROMPT
+    assert "{target_words}" in prompts.REFLECTION_PROMPT
     assert (
         "WICHTIG: Gib ausschließlich den aktualisierten Text zurück"
         in prompts.TEXT_TYPE_FIX_PROMPT

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -1830,8 +1830,22 @@ class WriterAgent:
         return improved, True
 
     def _generate_reflection(self, text: str, iteration: int) -> str | None:
+        current_words = self._count_words(text)
+        word_gap = max(self.word_count - current_words, 0)
+        prompt_template = prompts.REFLECTION_PROMPT.strip()
+        if prompt_template:
+            prompt_body = prompts.format_prompt(
+                prompt_template,
+                {
+                    "target_words": self.word_count,
+                    "current_words": current_words,
+                    "word_gap": word_gap,
+                },
+            )
+        else:
+            prompt_body = ""
         prompt = (
-            prompts.REFLECTION_PROMPT.strip()
+            prompt_body
             + "\n\nText:\n"
             + text.strip()
         )
@@ -1842,7 +1856,13 @@ class WriterAgent:
             system_prompt=prompts.REFLECTION_SYSTEM_PROMPT,
             success_message=f"Reflexion {iteration:02d} generiert",
             failure_message=f"Reflexion {iteration:02d} fehlgeschlagen",
-            data={"iteration": iteration, "phase": "reflection", "target_words": self.word_count},
+            data={
+                "iteration": iteration,
+                "phase": "reflection",
+                "target_words": self.word_count,
+                "current_words": current_words,
+                "word_gap": word_gap,
+            },
         )
 
     def _store_reflection(self, iteration: int, reflection: str | None) -> str | None:

--- a/wordsmith/prompts_config.json
+++ b/wordsmith/prompts_config.json
@@ -84,7 +84,7 @@
         },
         "reflection": {
             "system_prompt": "Du bist eine reflektierte Schreibmentor:in. Du identifizierst die wirksamsten nächsten Verbesserungen fokussiert, priorisierst nach Wirkung und lieferst klare Handlungsaufforderungen.",
-            "prompt": "Nenne die 3 wirksamsten nächsten Verbesserungen als priorisierte Markdown-Liste (1 = höchste Wirkung).\nJeder Punkt: maximal 15 Wörter, klar umsetzbar, mit Hinweis auf den betroffenen Abschnitt oder Absatz.\nFokussiere auf konkrete Handlungen, keine Allgemeinplätze.\n",
+            "prompt": "Nenne die 3 wirksamsten nächsten Verbesserungen als priorisierte Markdown-Liste (1 = höchste Wirkung).\nJeder Punkt: maximal 15 Wörter, klar umsetzbar, mit Hinweis auf den betroffenen Abschnitt oder Absatz.\nFokussiere auf konkrete Handlungen, keine Allgemeinplätze.\nFalls die aktuelle Länge ({current_words} Wörter) unter der Zielwortzahl von {target_words} Wörtern liegt, beginne mit einem Punkt, der präzise erklärt, wie die fehlenden {word_gap} Wörter inhaltlich gefüllt werden.\n",
             "parameters": {
                 "temperature": 0.7,
                 "top_p": 1.0,


### PR DESCRIPTION
## Summary
- extend the reflection prompt to mention the target word count when the draft is too short
- format the reflection prompt with the current word statistics during agent execution
- add regression tests covering the new prompt text and telemetry context

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d989b2cc4883258dd3a9b4f308198a