### PR TITLE
Refine reflection prompt to focus on single detailed task

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -167,7 +167,9 @@ def test_prompt_templates_emphasize_quality_controls() -> None:
     assert "Stil: {style}" in final_template
     assert "Zielwortzahl: {target_words}" in final_template
     assert "{format_instruction}" in final_template
-    assert "konkrete Handlungen" in prompts.REFLECTION_PROMPT
+    assert "wichtigsten nächsten Arbeitsauftrag" in prompts.REFLECTION_PROMPT
+    assert "nummerierten Markdown-Punkt" in prompts.REFLECTION_PROMPT
+    assert "2–3 präzise Sätze" in prompts.REFLECTION_PROMPT
     assert "Zielwortzahl" in prompts.REFLECTION_PROMPT
     assert "{current_words}" in prompts.REFLECTION_PROMPT
     assert "{target_words}" in prompts.REFLECTION_PROMPT

--- a/wordsmith/prompts_config.json
+++ b/wordsmith/prompts_config.json
@@ -84,7 +84,7 @@
         },
         "reflection": {
             "system_prompt": "Du bist eine reflektierte Schreibmentor:in. Du identifizierst die wirksamsten nächsten Verbesserungen fokussiert, priorisierst nach Wirkung und lieferst klare Handlungsaufforderungen.",
-            "prompt": "Nenne die 3 wirksamsten nächsten Verbesserungen als priorisierte Markdown-Liste (1 = höchste Wirkung).\nJeder Punkt: maximal 15 Wörter, klar umsetzbar, mit Hinweis auf den betroffenen Abschnitt oder Absatz.\nFokussiere auf konkrete Handlungen, keine Allgemeinplätze.\nFalls die aktuelle Länge ({current_words} Wörter) unter der Zielwortzahl von {target_words} Wörtern liegt, beginne mit einem Punkt, der präzise erklärt, wie die fehlenden {word_gap} Wörter inhaltlich gefüllt werden.\n",
+            "prompt": "Formuliere nur den wichtigsten nächsten Arbeitsauftrag als nummerierten Markdown-Punkt (1 = höchste Wirkung).\nSchreibe 2–3 präzise Sätze mit klarer Anleitung: benenne betroffene Abschnitte, konkrete Ergänzungen oder Streichungen, Tonalität und gewünschte Wirkung.\nVermeide Allgemeinplätze, bleibe handlungsleitend und füge keine weiteren Punkte hinzu.\nFalls die aktuelle Länge ({current_words} Wörter) unter der Zielwortzahl von {target_words} Wörtern liegt, integriere im Arbeitsauftrag genau, wie die fehlenden {word_gap} Wörter gefüllt werden sollen.\n",
             "parameters": {
                 "temperature": 0.7,
                 "top_p": 1.0,


### PR DESCRIPTION
## Summary
- adjust the reflection prompt to request a single, detailed work assignment instead of three brief bullets
- update prompt tests to assert the new guidance so the change remains covered

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da1ae760788325bd1c0797c5dedf46