### PR TITLE
Ensure section numbering remains unique during draft generation

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1217,6 +1217,35 @@ def test_clean_outline_sections_handles_all_zero_budgets(tmp_path: Path) -> None
     assert all(section.budget > 0 for section in cleaned)
 
 
+def test_clean_outline_sections_ensures_unique_numbers(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, 300)
+    agent = WriterAgent(
+        topic="Nummern",
+        word_count=300,
+        steps=[],
+        iterations=0,
+        config=config,
+        content="",
+        text_type="Blogartikel",
+        audience="Leser:innen",
+        tone="neutral",
+        register="Sie",
+        variant="DE-DE",
+        constraints="",
+        sources_allowed=False,
+    )
+
+    sections = [
+        OutlineSection("1", "Einleitung", "Hook", 100, "Rahmen setzen"),
+        OutlineSection("1", "Vertiefung", "Analyse", 100, "Details liefern"),
+        OutlineSection("", "Schluss", "Fazit", 100, "Abschluss formulieren"),
+    ]
+
+    cleaned = agent._clean_outline_sections(sections)
+
+    assert [section.number for section in cleaned] == ["1", "2", "3"]
+
+
 def test_generate_draft_from_outline_truncates_multi_section_output(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- normalise outline section numbers when cleaning the outline so each prompt targets the intended section
- add regression coverage to ensure duplicate or missing section numbers are renumbered sequentially

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da420654448325aea480d304c3536f