### PR TITLE
Fix outline parsing for inline metadata

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1187,6 +1187,24 @@ def test_parse_outline_sections_ignores_outline_feedback_block(tmp_path: Path) -
     assert sections[1].budget == 360
 
 
+def test_parse_outline_sections_supports_inline_metadata(tmp_path: Path) -> None:
+    agent = _build_agent(tmp_path, 600)
+    outline_text = (
+        "1. Einstieg – Rolle: Hook | Wortbudget: 120 Wörter | Liefergegenstand: Leser:innen fesseln\n"
+        "2. Hauptteil - Rolle: Analyse - Wortbudget: 360 Wörter - Liefergegenstand: Nutzen belegen\n"
+        "3. Schluss -> Handlungsimpuls geben – Rolle: Abschluss – Wortbudget: 120 Wörter\n"
+    )
+
+    sections = agent._parse_outline_sections(outline_text)
+
+    assert [section.number for section in sections] == ["1", "2", "3"]
+    assert sections[0].title == "Einstieg"
+    assert sections[0].role == "Hook"
+    assert sections[0].budget == 120
+    assert sections[1].deliverable == "Nutzen belegen"
+    assert sections[2].deliverable == "Handlungsimpuls geben"
+
+
 def test_clean_outline_sections_rebalances_overflow(tmp_path: Path) -> None:
     config = _build_config(tmp_path, 500)
     agent = WriterAgent(


### PR DESCRIPTION
## Summary
- make the outline parser accept inline metadata formats by extracting role, budget, and deliverable information outside parentheses
- normalise cleaned section titles and deliverables when metadata is embedded in dash or pipe separated segments
- add regression coverage to ensure inline metadata outlines are parsed into sections correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68da834f9ef483259081086608408b29