### PR TITLE
Track constructor overrides for LLM context length

### DIFF
--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -2193,10 +2193,16 @@ class WriterAgent:
             frequency_penalty=self.config.llm.frequency_penalty,
             seed=self.config.llm.seed,
             num_predict=getattr(self.config.llm, "num_predict", None),
+            num_ctx=getattr(self.config.llm, "num_ctx", None),
             stop=getattr(self.config.llm, "stop", ()),
         )
         if hasattr(base, "num_predict"):
             base.num_predict = getattr(self.config.llm, "num_predict", None)
+        if hasattr(base, "num_ctx"):
+            if self.config.llm.has_override("num_ctx"):
+                base.num_ctx = getattr(self.config.llm, "num_ctx", None)
+            else:
+                base.num_ctx = int(self.config.context_length)
         overrides = prompts.STAGE_PROMPT_PARAMETERS.get(prompt_type, {})
         for key, value in overrides.items():
             if key in {"temperature", "top_p"} and self.config.llm.has_override(key):

--- a/wordsmith/llm.py
+++ b/wordsmith/llm.py
@@ -105,6 +105,8 @@ def _prepare_options(parameters: LLMParameters) -> Dict[str, Any]:
         options["seed"] = parameters.seed
     if getattr(parameters, "num_predict", None) is not None:
         options["num_predict"] = int(parameters.num_predict)
+    if getattr(parameters, "num_ctx", None) is not None:
+        options["num_ctx"] = int(parameters.num_ctx)
     stop_sequences = getattr(parameters, "stop", ())
     if stop_sequences is None:
         options["stop"] = []


### PR DESCRIPTION
## Summary
- record constructor-supplied overrides in `LLMParameters` so explicit context windows survive configuration initialisation
- keep Ollama option preparation and tests asserting temperature, penalties, context, and generation limits are forwarded
- cover constructor override detection with dedicated configuration tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da82e036d4832587c59c5e029d9573