### PR TITLE
Improve section prompts with extracted idea bullets

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -262,6 +262,46 @@ def test_section_prompt_handles_missing_previous_sections(tmp_path: Path) -> Non
     assert "Noch kein Abschnitt verfasst." in prompt
 
 
+def test_section_prompt_prefers_extracted_idea_bullets(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, 200)
+    agent = WriterAgent(
+        topic="Feature",
+        word_count=200,
+        steps=[],
+        iterations=0,
+        config=config,
+        content="",
+        text_type="Reportage",
+        audience="Team",
+        tone="informativ",
+        register="Sie",
+        variant="DE-DE",
+        constraints="",
+        sources_allowed=False,
+    )
+
+    section = OutlineSection(
+        number="1",
+        title="Einblick",
+        role="Abschnitt",
+        budget=200,
+        deliverable="Überblick geben",
+    )
+
+    agent._idea_bullets = ["Fakten klar strukturieren", "Konkrete Beispiele nutzen"]
+
+    prompt = agent._build_section_prompt(
+        briefing={"goal": "Test"},
+        sections=[section],
+        section=section,
+        idea_text="Summary: sollte nicht erscheinen",
+        compiled_sections=[],
+    )
+
+    assert "Kernaussagen:\n- Fakten klar strukturieren\n- Konkrete Beispiele nutzen" in prompt
+    assert "Summary: sollte nicht erscheinen" not in prompt
+
+
 def test_call_llm_stage_stores_raw_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     config = _build_config(tmp_path, 150)
     config.llm_model = "dummy-model"

--- a/wordsmith/agent.py
+++ b/wordsmith/agent.py
@@ -825,6 +825,17 @@ class WriterAgent:
                         bullets.append(cleaned)
         return bullets
 
+    def _format_idea_context(self, fallback_text: str) -> str:
+        bullets = [bullet.strip() for bullet in self._idea_bullets if bullet.strip()]
+        if bullets:
+            return "\n".join(f"- {bullet}" for bullet in bullets)
+
+        cleaned = fallback_text.strip()
+        if cleaned:
+            return cleaned
+
+        return "[KLÄREN: Idee ergänzen]"
+
     def _create_outline_with_llm(self, briefing: dict) -> List[OutlineSection]:
         prompt = prompts.format_prompt(
             prompts.OUTLINE_PROMPT,
@@ -1542,7 +1553,7 @@ class WriterAgent:
             self._format_section_output(prev_section, text)
             for prev_section, text in compiled_sections
         ).strip()
-        idea_clean = idea_text.strip() or "[KLÄREN: Idee ergänzen]"
+        idea_clean = self._format_idea_context(idea_text)
         recap = self._build_previous_section_recap(compiled_sections)
         previous_sections_text = previous_text or "Noch kein Abschnitt verfasst."
 


### PR DESCRIPTION
## Summary
- use the extracted idea bullets when constructing section prompts so the LLM receives concise kernaussagen
- add a regression test that ensures section prompts prefer the bullet list over the raw idea text

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daa93726bc832593c7605e6b74fb61